### PR TITLE
Add git commit hash to RND output

### DIFF
--- a/relaxng/tools/make-doc.xpl
+++ b/relaxng/tools/make-doc.xpl
@@ -18,6 +18,15 @@
 
 <p:sink/>
 
+<p:exec command="git" source-is-xml='false' result-is-xml='false' name="rev-parse">
+  <p:input port="source">
+    <p:empty/>
+  </p:input>
+  <p:with-option name="args" select="'rev-parse HEAD'"/>
+</p:exec>
+
+<p:sink/>
+
 <p:load cx:depends-on="trang">
   <p:with-option name="href" select="concat('../schemas/build/', $schema, '/', $schema, '.rng')"/>
 </p:load>
@@ -44,6 +53,9 @@
   <p:input port="stylesheet">
     <p:document href="rngdocxml.xsl"/>
   </p:input>
+  <p:with-param name="buildhash" select="normalize-space(/)">
+    <p:pipe step="rev-parse" port="result"/>
+  </p:with-param>
 </p:xslt>
 
 <p:store name="store" method="xml" indent="true">

--- a/relaxng/tools/rngdocxml.xsl
+++ b/relaxng/tools/rngdocxml.xsl
@@ -13,6 +13,7 @@
   <xsl:key name="defs" match="rng:define" use="@name"/>
 
   <xsl:param name="debug" select="0"/>
+  <xsl:param name="buildhash" select="'UNKNOWN'"/>
 
   <xsl:template match="/">
     <xsl:if test="$debug != 0">
@@ -51,6 +52,13 @@
   </xsl:template>
 
   <!-- ====================================================================== -->
+  <xsl:template match="rng:grammar" mode="group">
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+      <xsl:attribute name="buildhash" select="$buildhash"/>
+      <xsl:apply-templates mode="group"/>
+    </xsl:copy>
+  </xsl:template>
 
   <xsl:template match="rng:define[count(*) &gt; 1]
 		       |rng:zeroOrMore[count(*) &gt; 1]


### PR DESCRIPTION
This will allow the generated documentation to precisely identify which version was used to build it.
