### PR TITLE
Updates for DocBook 5.2

### DIFF
--- a/relaxng/schemas/build.gradle
+++ b/relaxng/schemas/build.gradle
@@ -3,12 +3,12 @@ defaultTasks 'schemas', 'test'
 buildscript {
   repositories {
     mavenCentral()
-    maven { url "http://maven.restlet.org" }
+    maven { url "https://maven.restlet.org" }
   }
 
   dependencies {
-    classpath group: 'org.docbook', name: 'docbook-xslt2', version: '2.4.0'
-    classpath group: 'com.xmlcalabash', name: 'xmlcalabash1-gradle', version: '1.3.5'
+    classpath group: 'org.docbook', name: 'docbook-xslt2', version: '2.5.0'
+    classpath group: 'com.xmlcalabash', name: 'xmlcalabash1-gradle', version: '1.4.0'
   }
 }
 
@@ -635,7 +635,7 @@ task distDocBook5(type: XMLCalabashTask) {
   input("source", "docbook/index.xhtml")
   output("result", "build/dist/xml/${docbook_version}/index.html")
   option("version", "${docbook_version}")
-  option("tdg", "http://docbook.org/tdg51/en/html/")
+  option("tdg", "https://docbook.org/tdg51/en/html/")
   option("tdgtitle", "DocBook 5.1: The Definitive Guide")
 }
 
@@ -647,8 +647,8 @@ task distCatalog(type: XMLCalabashTask) {
   pipeline "../tools/catalog.xpl"
   input("source", "docbook/docbook-catalog.xml")
   output("result", "build/dist/xml/${docbook_version}/catalog.xml")
-  option("ROOT", "http://docbook.org/xml")
-  option("ROOT2", "http://www.docbook.org/xml")
+  option("ROOT", "https://docbook.org/xml")
+  option("ROOT2", "https://www.docbook.org/xml")
   option("VERSION", "${docbook_version}")
   doFirst {
     mkdir("build/dist/xml/${docbook_version}")
@@ -723,7 +723,7 @@ task distCatalogOASIS(type: XMLCalabashTask) {
   pipeline "../tools/catalog.xpl"
   input("source", "docbook/oasis-catalog.xml")
   output("result", "build/dist/docbook/docbook/${oasis_version}/${oasis_release}/catalog.xml")
-  option("ROOT", "http://docs.oasis-open.org/docbook/docbook")
+  option("ROOT", "https://docs.oasis-open.org/docbook/docbook")
   option("VERSION", "${oasis_version}")
   option("RELEASE", "${oasis_release}")
   doFirst {
@@ -779,7 +779,7 @@ task distPub4(type: XMLCalabashTask) {
   input("source", "publishers/index.xhtml")
   output("result", "build/dist/xml/publishers/${publishers_version}/index.html")
   option("version", "${publishers_version}")
-  option("tdg", "http://docbook.org/tdg51/publishers/en/html/")
+  option("tdg", "https://docbook.org/tdg51/publishers/en/html/")
   option("tdgtitle", "DocBook Publishers 5.1: The Definitive Guide")
 }
 
@@ -791,8 +791,8 @@ task distPubCatalog(type: XMLCalabashTask) {
   pipeline "../tools/catalog.xpl"
   input("source", "publishers/catalog.xml")
   output("result", "build/dist/xml/publishers/${publishers_version}/catalog.xml")
-  option("ROOT", "http://docbook.org/xml/publishers")
-  option("ROOT2", "http://www.docbook.org/xml/publishers")
+  option("ROOT", "https://docbook.org/xml/publishers")
+  option("ROOT2", "https://www.docbook.org/xml/publishers")
   option("VERSION", "${publishers_version}")
   doFirst {
     mkdir("build/dist/xml/publishers/${publishers_version}")
@@ -847,7 +847,7 @@ task distSimple4(type: XMLCalabashTask) {
   input("source", "sdocbook/index.xhtml")
   output("result", "build/dist/xml/sdocbook/${sdocbook_version}/index.html")
   option("version", "${sdocbook_version}")
-  option("tdg", "http://docbook.org/tdg51/sdocbook/en/html/")
+  option("tdg", "https://docbook.org/tdg51/sdocbook/en/html/")
   option("tdgtitle", "Simplified DocBook 5.1: The Definitive Guide")
 }
 
@@ -859,8 +859,8 @@ task distSimpleCatalog(type: XMLCalabashTask) {
   pipeline "../tools/catalog.xpl"
   input("source", "sdocbook/catalog.xml")
   output("result", "build/dist/xml/sdocbook/${sdocbook_version}/catalog.xml")
-  option("ROOT", "http://docbook.org/xml/sdocbook")
-  option("ROOT2", "http://www.docbook.org/xml/sdocbook")
+  option("ROOT", "https://docbook.org/xml/sdocbook")
+  option("ROOT2", "https://www.docbook.org/xml/sdocbook")
   option("VERSION", "${sdocbook_version}")
   doFirst {
     mkdir("build/dist/xml/sdocbook/${sdocbook_version}")
@@ -918,7 +918,7 @@ task distSlides4(type: XMLCalabashTask) {
   input("source", "slides/index.xhtml")
   output("result", "build/dist/xml/slides/${slides_version}/index.html")
   option("version", "${slides_version}")
-  option("tdg", "http://docbook.org/tdg51/slides/en/html/")
+  option("tdg", "https://docbook.org/tdg51/slides/en/html/")
   option("tdgtitle", "DocBook Slides 5.1: The Definitive Guide")
 }
 
@@ -930,8 +930,8 @@ task distSlidesCatalog(type: XMLCalabashTask) {
   pipeline "../tools/catalog.xpl"
   input("source", "slides/catalog.xml")
   output("result", "build/dist/xml/slides/${slides_version}/catalog.xml")
-  option("ROOT", "http://docbook.org/xml/slides")
-  option("ROOT2", "http://www.docbook.org/xml/slides")
+  option("ROOT", "https://docbook.org/xml/slides")
+  option("ROOT2", "https://www.docbook.org/xml/slides")
   option("VERSION", "${slides_version}")
   doFirst {
     mkdir("build/dist/xml/slides/${slides_version}")
@@ -989,7 +989,7 @@ task distWebsite4(type: XMLCalabashTask) {
   input("source", "website/index.xhtml")
   output("result", "build/dist/xml/website/${website_version}/index.html")
   option("version", "${website_version}")
-  option("tdg", "http://docbook.org/tdg51/website/en/html/")
+  option("tdg", "https://docbook.org/tdg51/website/en/html/")
   option("tdgtitle", "DocBook Website 5.1: The Definitive Guide")
 }
 
@@ -1001,8 +1001,8 @@ task distWebsiteCatalog(type: XMLCalabashTask) {
   pipeline "../tools/catalog.xpl"
   input("source", "website/catalog.xml")
   output("result", "build/dist/xml/website/${website_version}/catalog.xml")
-  option("ROOT", "http://docbook.org/xml/website")
-  option("ROOT2", "http://www.docbook.org/xml/website")
+  option("ROOT", "https://docbook.org/xml/website")
+  option("ROOT2", "https://www.docbook.org/xml/website")
   option("VERSION", "${website_version}")
   doFirst {
     mkdir("build/dist/xml/website/${website_version}")

--- a/relaxng/schemas/docbook/programming.rnc
+++ b/relaxng/schemas/docbook/programming.rnc
@@ -1224,13 +1224,21 @@ div {
 div {
 
    db.unionsynopsis.role.attribute = attribute role { text }
+
+   # N.B. the enumeration is explicitly identical to the enumeration
+   # on enumsynopsis by default.
+   db.unionsynopsis.ordered.attribute =
+      [
+         db:refpurpose [ "Indicates how the value of a union is specified." ]
+      ]
+      attribute ordered { db.enumsynopsis.ordered.enumeration }
        
    db.unionsynopsis.attlist =
       db.unionsynopsis.role.attribute?
     & db.common.attributes
     & db.common.linking.attributes
     & db.language.attribute?
-    & db.enumsynopsis.ordered.attribute?
+    & db.unionsynopsis.ordered.attribute?
    
    db.unionsynopsis = 
       element unionsynopsis {
@@ -1247,7 +1255,7 @@ div {
 
 [
    db:refname [ "enumname" ]
-   db:refpurpose [ "The name of a union of types" ]
+   db:refpurpose [ "The name of an enumeration" ]
 ]
 div {
 
@@ -1371,14 +1379,17 @@ div {
    db.enumsynopsis.role.attribute = attribute role { text }
 
    db.enumsynopsis.ordered.enumeration =
-  
       ## Value of enum is specified explicitly using enumvalue
    "0"
     | 
       ## Value of enum is inferred from its position
    "1"
 
-   db.enumsynopsis.ordered.attribute = attribute ordered { db.enumsynopsis.ordered.enumeration }
+   db.enumsynopsis.ordered.attribute =
+      [
+         db:refpurpose [ "Indicates how the value of an enumeration is specified." ]
+      ]
+      attribute ordered { db.enumsynopsis.ordered.enumeration }
    
    db.enumsynopsis.attlist =
       db.enumsynopsis.role.attribute?

--- a/relaxng/schemas/gradle.properties
+++ b/relaxng/schemas/gradle.properties
@@ -7,12 +7,11 @@ mkschema= ../tools/make-schema.xpl
 mkschematron= ../tools/make-schematron.xpl
 mkdoc ../tools/make-doc.xpl
 
-docbook_version = 5.2b08
+docbook_version = 5.2b09a
 oasis_version = v5.2
-oasis_release = b08
+oasis_release = b09a
 
-publishers_version = 5.2b08
-
-sdocbook_version = 5.2b08
-website_version = 5.2b08
-slides_version = 5.2b08
+publishers_version = 5.2b09a
+sdocbook_version = 5.2b09a
+website_version = 5.2b09a
+slides_version = 5.2b09a

--- a/relaxng/schemas/gradle/wrapper/gradle-wrapper.properties
+++ b/relaxng/schemas/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/relaxng/schemas/gradlew
+++ b/relaxng/schemas/gradlew
@@ -125,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/relaxng/schemas/publishers/publishers.rnc
+++ b/relaxng/schemas/publishers/publishers.rnc
@@ -290,6 +290,7 @@ div {
   db.sect3 = notAllowed
   db.sect4 = notAllowed
   db.sect5 = notAllowed
+  db.legalsection = notAllowed
   db.seealsoie = notAllowed
   db.seeie = notAllowed
   db.seg = notAllowed
@@ -303,6 +304,7 @@ div {
   db.synopfragmentref = notAllowed
   db.synopsis = notAllowed
   db.systemitem = notAllowed
+  db.buildtarget = notAllowed
   db.tag = notAllowed
   db.html.td = notAllowed
   db.tertiaryie = notAllowed

--- a/relaxng/tools/make-schema.xpl
+++ b/relaxng/tools/make-schema.xpl
@@ -10,10 +10,6 @@
 <p:option name="remove-schematron" select="0"/>
 <p:option name="make-rnc" select="'1'"/>
 
-<!--
-TRANG=java -cp $(CLASSPATH) com.thaiopensource.relaxng.translate.Driver
--->
-
 <p:exec command="java" source-is-xml='false' result-is-xml='false' name="trang">
   <p:input port="source">
     <p:empty/>
@@ -65,7 +61,7 @@ TRANG=java -cp $(CLASSPATH) com.thaiopensource.relaxng.translate.Driver
   <p:with-param name="release" select="$release"/>
 </p:template>
 
-<p:xslt>
+<p:xslt name="final">
   <p:input port="source">
     <p:pipe step="schema" port="result"/>
   </p:input>
@@ -81,13 +77,25 @@ TRANG=java -cp $(CLASSPATH) com.thaiopensource.relaxng.translate.Driver
   <p:with-option name="href" select="concat(exf:cwd(), '/', $schema, '.rng')"/>
 </p:store>
 
+<!-- Store it without indentation so that trang doesn't put a whole bunch
+     of ugly, spurious whitespace nodes in the Schematron rules. -->
+<p:store name="store-fixws" method="xml" indent="false">
+  <p:input port="source">
+    <p:pipe step="final" port="result"/>
+  </p:input>
+  <p:with-option name="href"
+                 select="concat(exf:cwd(), '/build/', $schema, '-ws.rng')"/>
+</p:store>
+
 <p:choose>
   <p:when test="$make-rnc != '0'">
-    <p:exec command="java" source-is-xml='false' result-is-xml='false' cx:depends-on="store">
+    <p:exec command="java" source-is-xml='false' result-is-xml='false'
+            cx:depends-on="store-fixws">
       <p:input port="source">
         <p:empty/>
       </p:input>
-      <p:with-option name="args" select="concat('-jar ../../lib/trang-2009-11-11.jar ', $schema,'.rng ',$schema,'.rnc')">
+      <p:with-option name="args"
+         select="concat('-jar ../../lib/trang-2009-11-11.jar build/', $schema,'-ws.rng ',$schema,'.rnc')">
         <p:empty/>
       </p:with-option>
     </p:exec>


### PR DESCRIPTION
1. I fixed the #135 
2. I fixed a bug where several elements were sharing a common declaration for an attribute. That's a bad idea because it makes it more difficult to customize them independently.
3. I upgraded the infrastructure.
4. I updated the publishers schema to exclude legalsection and buildtarget
5. I removed the ugly whitespace from .rnc files.
