### PR TITLE
Proposed fix for issues related to the new synopsis elements

### DIFF
--- a/src/main/relaxng/docbook/programming.rnc
+++ b/src/main/relaxng/docbook/programming.rnc
@@ -31,7 +31,7 @@ db.programming.inlines =
  | db.initializer
  | db.buildtarget
  | db.oo.inlines
- | db.templateid
+ | db.templatename
  | db.namespace
  | db.namespacename
  | db.macroname
@@ -112,7 +112,7 @@ div {
    db.synopsisinfo =
       element synopsisinfo {
          db.synopsisinfo.attlist,
-        (db.verbatim.contentmodel | (db.programming.inlines?, db.all.blocks*))
+         db.verbatim.contentmodel
       }
 }
 
@@ -123,6 +123,7 @@ div {
    db:refpurpose [ "The syntax summary for a function definition" ]
 ]
 div {
+   db.funcsynopsis.info = db._info.title.forbidden
 
    db.funcsynopsis.role.attribute = attribute role { text }
 
@@ -131,8 +132,6 @@ div {
     & db.common.attributes
     & db.common.linking.attributes
     & db.language.attribute?
-
-   db.funcsynopsis.info = db._info.title.forbidden
 
    db.funcsynopsis =
       element funcsynopsis {
@@ -208,7 +207,7 @@ div {
    db.funcdef =
       element funcdef {
          db.funcdef.attlist,
-         (db._text | db.type | db.templateid | db.void | db.function)*
+         (db._text | db.type | db.templatename | db.void | db.function)*
       }
 }
 
@@ -335,7 +334,7 @@ div {
    db.paramdef =
       element paramdef {
          db.paramdef.attlist,
-         (db._text | db.initializer | db.modifier | db.type | db.templateid | db.parameter | db.funcparams)*
+         (db._text | db.initializer | db.modifier | db.type | db.templatename | db.parameter | db.funcparams)*
       }
 }
 
@@ -368,6 +367,7 @@ div {
    db:refpurpose [ "The syntax summary for a class definition" ]
 ]
 div {
+   db.classsynopsis.info = db._info.title.forbidden
 
    db.classsynopsis.role.attribute = attribute role { text }
 
@@ -393,16 +393,17 @@ div {
    db.classsynopsis =
       element classsynopsis {
          db.classsynopsis.attlist,
-         db.template*,
-         (db.oo.inlines | db.classname)+,
-         db.template*,
-         (db.classsynopsisinfo
-          | db.synopsisinfo
+         db.classsynopsis.info,
+         db.classsynopsisinfo*,
+         db.templatename*,
+         db.oo.inlines,
+         (db.template
+          | db.ooexception
           | db.methodsynopsis
           | db.constructorsynopsis
           | db.destructorsynopsis
-          | db.fieldsynopsis)*,
-         db.recursive.blocks.or.sections?
+          | db.fieldsynopsis
+          | db.classsynopsisinfo)*
       }
 }
 
@@ -591,6 +592,7 @@ div {
    db:refpurpose [ "The name of a field in a class definition" ]
 ]
 div {
+   db.fieldsynopsis.info = db._info.title.forbidden
 
    db.fieldsynopsis.role.attribute = attribute role { text }
 
@@ -603,8 +605,9 @@ div {
    db.fieldsynopsis =
       element fieldsynopsis {
          db.fieldsynopsis.attlist,
+         db.fieldsynopsis.info,
          db.modifier*,
-         (db.type | db.templateid)*,
+         (db.type | db.templatename)*,
          db.varname,
          db.initializer?
       }
@@ -641,6 +644,7 @@ div {
    db:refpurpose [ "A syntax summary for a constructor" ]
 ]
 div {
+   db.constructorsynopsis.info = db._info.title.forbidden
 
    db.constructorsynopsis.role.attribute = attribute role { text }
 
@@ -653,6 +657,7 @@ div {
    db.constructorsynopsis =
       element constructorsynopsis {
          db.constructorsynopsis.attlist,
+         db.constructorsynopsis.info,
          db.modifier*,
          db.methodname?,
          ((db.methodparam|db.group.methodparam)+ | db.void?),
@@ -667,6 +672,7 @@ div {
    db:refpurpose [ "A syntax summary for a destructor" ]
 ]
 div {
+   db.destructorsynopsis.info = db._info.title.forbidden
 
    db.destructorsynopsis.role.attribute = attribute role { text }
 
@@ -679,6 +685,7 @@ div {
    db.destructorsynopsis =
       element destructorsynopsis {
          db.destructorsynopsis.attlist,
+         db.destructorsynopsis.info,
          db.modifier*,
          db.methodname?,
          ((db.methodparam|db.group.methodparam)+ | db.void?),
@@ -693,6 +700,7 @@ div {
    db:refpurpose [ "A syntax summary for a method" ]
 ]
 div {
+   db.methodsynopsis.info = db._info.title.forbidden
 
    db.methodsynopsis.role.attribute = attribute role { text }
 
@@ -705,17 +713,15 @@ div {
    db.methodsynopsis =
       element methodsynopsis {
          db.methodsynopsis.attlist,
-         db.template*,
-         db.modifier*,
-         (db.type+ | db.templateid+ | db.void)?,
-         db.methodname,
-         db.template*,
-         ((db.methodparam|db.group.methodparam)+ | db.void),
-         db.exceptionname*,
-         db.modifier*,
-         db.template*,
+         db.methodsynopsis.info,
          db.synopsisinfo*,
-         db.recursive.blocks.or.sections?
+         (db.templatename | db.modifier)*,
+         (db.type | db.void)?,
+         db.methodname,
+         db.templatename*,
+         ((db.methodparam|db.group.methodparam)+ | db.void),
+         (db.exceptionname | db.modifier | db.templatename)*,
+         db.synopsisinfo*
       }
 }
 
@@ -763,12 +769,9 @@ div {
    db.methodparam =
       element methodparam {
          db.methodparam.attlist,
-         db.modifier*,
-         (db.type | db.templateid)*,
-         ((db.modifier*, db.parameter, db.initializer?)
-          | db.funcparams),
-         db.modifier*,
-         db.recursive.blocks.or.sections?
+         (db.modifier | db.type | db.templatename)*,
+         ((db.parameter, db.initializer?) | db.funcparams),
+         db.modifier*
       }
 }
 
@@ -892,7 +895,7 @@ div {
    db.type =
       element type {
          db.type.attlist,
-         (db._text | db.type | db.templateid | db.programming.inlines)*
+         (db._text | db.programming.inlines)*
       }
 }
 
@@ -921,21 +924,21 @@ div {
 # ======================================================================
 
 [
-   db:refname [ "templateid" ]
+   db:refname [ "templatename" ]
    db:refpurpose [ "The identifier for a template, in the generic programming sense" ]
 ]
 div {
 
-  db.templateid.role.attribute = attribute role { text }
+  db.templatename.role.attribute = attribute role { text }
 
-  db.templateid.attlist =
-     db.templateid.role.attribute?
+  db.templatename.attlist =
+     db.templatename.role.attribute?
    & db.common.attributes
    & db.common.linking.attributes
   
-  db.templateid =
-     element templateid {
-        db.templateid.attlist,
+  db.templatename =
+     element templatename {
+        db.templatename.attlist,
         db._text
      }
 }
@@ -959,7 +962,7 @@ div {
      element template {
         db.template.attlist,
         (((db.modifier | db.type | db._text)*,
-         db.templateid,
+         db.templatename,
          (db.modifier | db.type | db._text)*) 
          | db.specializedtemplate)
      }
@@ -1039,6 +1042,7 @@ div {
    db:refpurpose [ "The syntax summary for a name space definition" ]
 ]
 div {
+   db.namespacesynopsis.info = db._info.title.forbidden
 
    db.namespacesynopsis.role.attribute = attribute role { text }
    
@@ -1051,19 +1055,13 @@ div {
    db.namespacesynopsis = 
       element namespacesynopsis { 
          db.namespacesynopsis.attlist,
+         db.namespacesynopsis.info,
+         db.synopsisinfo*,
+         (db.package | db.modifier)*,
          (db.namespace | db.namespacename),
-         db.recursive.blocks.or.sections?, 
-         (db.synopsisinfo
-          | db.classsynopsis
-          | db.funcsynopsis
-          | db.fieldsynopsis
-          | db.typedefsynopsis
-          | db.macrosynopsis
-          | db.enumsynopsis
-          | db.namespacesynopsis)*, 
-         db.recursive.blocks.or.sections?
+         (db.package | db.modifier)*,
+         db.synopsisinfo*
       }
-   
 }
 
 # ======================================================================
@@ -1096,6 +1094,7 @@ div {
    db:refpurpose [ "The syntax summary for a macro definition (code-generating function)" ]
 ]
 div {
+   db.macrosynopsis.info = db._info.title.forbidden
 
    db.macrosynopsis.role.attribute = attribute role { text }
    
@@ -1108,13 +1107,14 @@ div {
    db.macrosynopsis =
       element macrosynopsis {
          db.macrosynopsis.attlist,
-         db.macroname,
+         db.macrosynopsis.info,
          db.synopsisinfo*,
+         (db.package | db.modifier)*,
+         db.macroname,
+         (db.package | db.modifier)*,
          db.macroprototype+,
-         db.synopsisinfo*, 
-         db.recursive.blocks.or.sections?
+         db.synopsisinfo*
       }
-   
 }
 
 # ======================================================================
@@ -1163,7 +1163,7 @@ div {
    db.macrodef =
       element macrodef {
          db.macrodef.attlist,
-         (db.type | db.templateid)*, db.macroname
+         (db.type | db.templatename)*, db.macroname
       }
    
 }
@@ -1209,8 +1209,7 @@ div {
    db.union =
       element union {
          db.union.attlist,
-         db.unionname?,
-         db.programming.inlines*
+         db.unionname+
       }
    
 }
@@ -1222,6 +1221,7 @@ div {
    db:refpurpose [ "The syntax summary for a union-of-types definition" ]
 ]
 div {
+   db.unionsynopsis.info = db._info.title.forbidden
 
    db.unionsynopsis.role.attribute = attribute role { text }
 
@@ -1242,11 +1242,14 @@ div {
    
    db.unionsynopsis = 
       element unionsynopsis {
-         db.unionsynopsis.attlist, 
-         db.unionname?,
-         db.union?, 
+         db.unionsynopsis.attlist,
+         db.unionsynopsis.info,
          db.synopsisinfo*,
-         db.recursive.blocks.or.sections?
+         (db.package | db.modifier)*,
+         db.unionname?,
+         db.union, 
+         (db.package | db.modifier)*,
+         db.synopsisinfo*
       }
    
 }
@@ -1360,9 +1363,9 @@ div {
    
    db.enumitem =
       element enumitem {
-         db.enumvalue.attlist,
+         db.enumitem.attlist,
          db.enumidentifier,
-         db.enumvalue?,
+         db.enumvalue*,
          db.enumitemdescription?
       }
    
@@ -1375,6 +1378,7 @@ div {
    db:refpurpose [ "The syntax summary for an enumerated-type definition" ]
 ]
 div {
+   db.enumsynopsis.info = db._info.title.forbidden
 
    db.enumsynopsis.role.attribute = attribute role { text }
 
@@ -1401,10 +1405,12 @@ div {
    db.enumsynopsis = 
       element enumsynopsis {
          db.enumsynopsis.attlist, 
-         db.enumname?, 
+         db.enumsynopsis.info,
          db.synopsisinfo*,
-         db.enumitem+, 
-         db.recursive.blocks.or.sections?
+         (db.package | db.modifier)*,
+         db.enumname?,
+         db.enumitem+,
+         db.synopsisinfo*
       }
    
 }
@@ -1439,6 +1445,7 @@ div {
    db:refpurpose [ "The syntax summary for a type-alias definition" ]
 ]
 div {
+   db.typedefsynopsis.info = db._info.title.forbidden
 
    db.typedefsynopsis.role.attribute = attribute role { text }
 
@@ -1451,9 +1458,12 @@ div {
    db.typedefsynopsis = 
       element typedefsynopsis {
          db.typedefsynopsis.attlist, 
-         db.typedefname, 
-         db.programming.inlines*, 
-         db.recursive.blocks.or.sections?
+         db.typedefsynopsis.info,
+         db.synopsisinfo*,
+         (db.package | db.modifier)*,
+         db.typedefname,
+         (db.package | db.modifier)*,
+         db.synopsisinfo*
       }
    
 }

--- a/src/test/docbook/pass/classsynopsis.002.xml
+++ b/src/test/docbook/pass/classsynopsis.002.xml
@@ -9,24 +9,32 @@
       </db:abstract>
    </db:info>
    <db:classsynopsis>
-      <db:ooclass><db:package>java.nio.file</db:package><db:classname>Files</db:classname></db:ooclass>
+      <db:ooclass>
+        <db:package>java.nio.file</db:package>
+        <db:classname>Files</db:classname>
+      </db:ooclass>
+      <db:ooexception xml:id='iae'>
+        <db:exceptionname>IllegalArgumentException</db:exceptionname>
+      </db:ooexception>
       <db:methodsynopsis>
          <db:methodname>write</db:methodname>
-         <db:methodparam>
+         <db:methodparam xml:id="fp">
             <db:type>Path</db:type>
             <db:parameter>path</db:parameter>
-            <db:para>the path to the file</db:para>
          </db:methodparam>
-         <db:methodparam>
+         <db:methodparam xml:id="fb">
             <db:type>byte[]</db:type>
             <db:parameter>bytes</db:parameter>
-            <db:para>the byte array with the bytes to write</db:para>
          </db:methodparam>
-         <db:synopsisinfo role="throws">
-            <db:exceptionname>IllegalArgumentException</db:exceptionname>
-            <db:para>if options contains an invalid combination of options</db:para>
-         </db:synopsisinfo>
-         <db:para>Writes bytes to a file. […]</db:para>
       </db:methodsynopsis>
    </db:classsynopsis>
+
+<db:para>This class defines methods to operation on files.</db:para>
+
+<db:para>The <db:classname>write</db:classname> method writes bytes to
+a file. The <db:link linkend="fp">path</db:link>specifies the path to the
+file, <db:link linkend="fb">bytes</db:link> specifies the data to be written.
+An <db:exceptionname linkend="iae">IllegalArguementException</db:exceptionname> is throw
+if some circumstance arises.</db:para>
+
 </db:article>

--- a/src/test/docbook/pass/classsynopsis.003.xml
+++ b/src/test/docbook/pass/classsynopsis.003.xml
@@ -4,28 +4,39 @@
     version="5.2">
     <db:title>Java generics</db:title>
     <db:para>An example inspired by <db:link xlink:href="https://docs.julialang.org/en/v1/manual/types/index.html#Parametric-Types-1">Julia's documentation</db:link>.</db:para>
+
+<db:section>
+<db:title>Point</db:title>
     
     <db:classsynopsis>
+      <db:ooclass>
         <db:classname>Point</db:classname>
+      </db:ooclass>
         <db:template>
-            <db:templateid>T</db:templateid>
+            <db:templatename>T</db:templatename>
         </db:template>
         
         <db:fieldsynopsis>
-            <db:templateid>T</db:templateid>
+            <db:templatename>T</db:templatename>
             <db:varname>x</db:varname>
         </db:fieldsynopsis>
         
         <db:fieldsynopsis>
-            <db:templateid>T</db:templateid>
+            <db:templatename>T</db:templatename>
             <db:varname>y</db:varname>
         </db:fieldsynopsis>
-        
-        <db:para>Class Point.</db:para>
     </db:classsynopsis>
+
+<db:para>A point.</db:para>
+</db:section>
+
+<db:section>
+<db:title>Specialized point</db:title>
     
     <db:classsynopsis>
+      <db:ooclass>
         <db:classname>Point</db:classname>
+      </db:ooclass>
         <db:template>
             <db:specializedtemplate>Float64</db:specializedtemplate>
         </db:template>
@@ -39,20 +50,24 @@
             <db:type>Float64</db:type>
             <db:varname>y</db:varname>
         </db:fieldsynopsis>
-        
-        <db:para>Specialized class Point.</db:para>
     </db:classsynopsis>
+
+<db:para>A specialized point.</db:para>
+</db:section>
+
+<db:section>
+<db:title>Translation</db:title>
     
     <db:methodsynopsis>
         <db:methodname>translate_point</db:methodname>
         <db:methodparam>
             <db:type>
-                <db:classname>Point</db:classname>{<db:templateid>T</db:templateid>}
+                <db:classname>Point</db:classname>{<db:templatename>T</db:templatename>}
             </db:type>
             <db:parameter>p</db:parameter>
         </db:methodparam>
-        <db:template>
-            where <db:templateid>T</db:templateid>
-        </db:template>
+        <db:templatename>T</db:templatename>
     </db:methodsynopsis>
+
+</db:section>
 </db:article>

--- a/src/test/docbook/pass/enumsynopsis.001.xml
+++ b/src/test/docbook/pass/enumsynopsis.001.xml
@@ -54,7 +54,11 @@
             </db:enumitem>
             <db:enumitem>
                <db:enumidentifier>AlignHorizontal_Mask</db:enumidentifier>
-               <db:enumvalue>AlignLeft | AlignRight | AlignHCenter | AlignJustify | AlignAbsolute</db:enumvalue>
+               <db:enumvalue>AlignLeft</db:enumvalue>
+               <db:enumvalue>AlignRight</db:enumvalue>
+               <db:enumvalue>AlignHCenter</db:enumvalue>
+               <db:enumvalue>AlignJustify</db:enumvalue>
+               <db:enumvalue>AlignAbsolute</db:enumvalue>
             </db:enumitem>
             <db:enumitem>
                <db:enumidentifier>AlignTop</db:enumidentifier>
@@ -74,11 +78,15 @@
             </db:enumitem>
             <db:enumitem>
                <db:enumidentifier>AlignVertical_Mask</db:enumidentifier>
-               <db:enumvalue>AlignTop | AlignBottom | AlignVCenter | AlignBaseline</db:enumvalue>
+               <db:enumvalue>AlignTop</db:enumvalue>
+               <db:enumvalue>AlignBottom</db:enumvalue>
+               <db:enumvalue>AlignVCenter</db:enumvalue>
+               <db:enumvalue>AlignBaseline</db:enumvalue>
             </db:enumitem>
             <db:enumitem>
                <db:enumidentifier>AlignCenter</db:enumidentifier>
-               <db:enumvalue>AlignVCenter | AlignHCenter</db:enumvalue>
+               <db:enumvalue>AlignVCenter</db:enumvalue>
+               <db:enumvalue>AlignHCenter</db:enumvalue>
             </db:enumitem>
          </db:enumsynopsis>
          <db:typedefsynopsis>

--- a/src/test/docbook/pass/template.001.xml
+++ b/src/test/docbook/pass/template.001.xml
@@ -5,11 +5,13 @@
     <db:title>C++ template</db:title>
     <db:para>An example inspired by <db:link xlink:href="https://en.cppreference.com/w/cpp/language/templates">CppReference</db:link>.</db:para>
     <db:classsynopsis>
+      <db:ooclass>
         <db:classname>X</db:classname>
+      </db:ooclass>
         <db:template>
             <db:modifier>class</db:modifier>
-            <db:templateid>T</db:templateid>
+            <db:templatename>T</db:templatename>
         </db:template>
-        <db:para>Class X.</db:para>
     </db:classsynopsis>
+    <db:para>Class X.</db:para>
 </db:article>

--- a/src/test/docbook/pass/template.002.xml
+++ b/src/test/docbook/pass/template.002.xml
@@ -5,16 +5,18 @@
     <db:title>Java generics</db:title>
     <db:para>An example inspired by <db:link xlink:href="https://en.wikipedia.org/wiki/Generics_in_Java#Generic_class_definitions">Wikipedia</db:link>.</db:para>
     <db:classsynopsis>
+      <db:ooclass>
         <db:classname>Entry</db:classname>
+      </db:ooclass>
         <db:template>
-            <db:templateid>KeyType</db:templateid>
+            <db:templatename>KeyType</db:templatename>
         </db:template>
         <db:template>
             <!-- Show how to model type wildcards. -->
-            <db:templateid>ValueType</db:templateid>
+            <db:templatename>ValueType</db:templatename>
             <db:modifier>extends</db:modifier>
             <db:type>Number</db:type>
         </db:template>
-        <db:para>Class Entry.</db:para>
     </db:classsynopsis>
+        <db:para>Class Entry.</db:para>
 </db:article>

--- a/src/test/docbook/pass/typedefsynopsis.001.xml
+++ b/src/test/docbook/pass/typedefsynopsis.001.xml
@@ -13,14 +13,16 @@
       <db:productnumber>1.2</db:productnumber>
    </db:info>
    <db:classsynopsis>
+     <db:info>
+      <db:releaseinfo role="threadsafety">reentrant</db:releaseinfo>
+      <db:releaseinfo role="module">QtCore</db:releaseinfo>
+      <db:releaseinfo role="group">io</db:releaseinfo>
+      <db:releaseinfo role="group">shared</db:releaseinfo>
+     </db:info>
+      <db:classsynopsisinfo role="headers">#include &lt;qfileinfo.h&gt;</db:classsynopsisinfo>
       <db:ooclass>
          <db:classname>QFileInfo</db:classname>
       </db:ooclass>
-      <db:synopsisinfo role="threadsafety">reentrant</db:synopsisinfo>
-      <db:synopsisinfo role="module">QtCore</db:synopsisinfo>
-      <db:synopsisinfo role="headers">#include &lt;qfileinfo.h&gt;</db:synopsisinfo>
-      <db:synopsisinfo role="group">io</db:synopsisinfo>
-      <db:synopsisinfo role="group">shared</db:synopsisinfo>
    </db:classsynopsis>
    <db:section xml:id="details">
       <db:title>Detailed Description</db:title>

--- a/src/test/docbook/pass/unionsynopsis.001.xml
+++ b/src/test/docbook/pass/unionsynopsis.001.xml
@@ -9,17 +9,16 @@
       </db:abstract>
    </db:info>
    <db:unionsynopsis>
-      <db:union>
-         <db:unionname>IntOrString</db:unionname>
-         <db:type>Int</db:type>
-         <db:type>AbstractString</db:type>
-      </db:union>
+     <db:union>
+       <db:unionname>Int</db:unionname>
+       <db:unionname>AbstractString</db:unionname>
+     </db:union>
    </db:unionsynopsis>
    <db:unionsynopsis>
       <db:unionname>IntOrString</db:unionname>
       <db:union>
-         <db:type>Int</db:type>
-         <db:type>AbstractString</db:type>
+         <db:unionname>Int</db:unionname>
+         <db:unionname>AbstractString</db:unionname>
       </db:union>
    </db:unionsynopsis>
 </db:article>


### PR DESCRIPTION
(This PR is the same as #147, it's simply been recast on the reorganized repository.)

My humble proposal for fixing the issues I've identified with the new synopsis elements. Fix #143 and fix #144.

* Rename `templateid` to `templatename`. That's more consistent with `classname`, `methodname`, etc.
* Remove inlines and blocks from `synopsisinfo`. It's a verbatim environment.
* Allow optional `info` blocks (with titles forbidden) to the synopsis elements. It makes sense to allow metadata and at least one of the examples in the test suite benefits from it.
* Allow `synopsisinfo` a little more consistently.
* Remove blocks and sections from `classsynopsis`, mix in `templatename`.
* Remove blocks and sections from `methodsynopsis`, mix in `templatename`.
* Remove blocks and sections from `methodparam`, mix in `templatename`.
* Cleanup the declaration for `type` (`type` and `templatename` are in `db.programming.inlines`)
* Remove blocks and sections from `namespacesynopsis`, mix in `package` and `modifier`.
* Remove `classsynopsis`, `funcsynopsis`, etc. from `namespacesynopsis`.
* Remove blocks and sections from `macrosynopsis`, mix in `package` and `modifier`.
* Changed `unionname?` to `unionname*` in `union`. It made one of the examples cleaner, I think.
* Remove blocks and sections from `unionsynopsis`, mix in `package` and `modifier`.
* Changed `enumvalue?` to `enumvalue*` in `enumitem`. It made one of the examples cleaner, I think.
* Remove blocks and sections from `enumsynopsis`, mix in `package` and `modifier`.
* Remove blocks and sections from `typedefsynopsis`, mix in `package` and `modifier`.

I’m not uniformly pleased with `db.programming.inlines` in `db.type`, but I’m not sure what more than `db.type` and `db.templatename` was considered necessary.

Mixing in `package` and `modifier` in a few more places is for consistency.

I can’t tell if having all of the synopsis elements inside `namespacesynopsis` was intentional or not. It seems very odd to me, but it may have been intentional.

On the whole, it seems to me that `templatename` outside of `template` is being used as a kind of modifier. I think I’d have argued to make it a class on `modifier`, but I’m trying to do the bare minimum changes in this proposal.
