### PR TITLE
Add pubwork/otherpubwork to biblioentry/bibliomixed

### DIFF
--- a/src/main/relaxng/docbook/bibliography.rnc
+++ b/src/main/relaxng/docbook/bibliography.rnc
@@ -32,8 +32,11 @@ div {
 
    db.biblioentry.role.attribute = attribute role { text }
 
+   db.biblioentry.pubwork.attribute = db.biblio.pubwork.attribute
+
    db.biblioentry.attlist =
       db.biblioentry.role.attribute?
+    & db.biblioentry.pubwork.attribute?
     & db.common.attributes
     & db.common.linking.attributes
 
@@ -54,8 +57,11 @@ div {
 
    db.bibliomixed.role.attribute = attribute role { text }
 
+   db.bibliomixed.pubwork.attribute = db.biblio.pubwork.attribute
+
    db.bibliomixed.attlist =
       db.bibliomixed.role.attribute?
+    & db.bibliomixed.pubwork.attribute?
     & db.common.attributes
     & db.common.linking.attributes
 

--- a/src/main/relaxng/docbook/pool.rnc
+++ b/src/main/relaxng/docbook/pool.rnc
@@ -669,6 +669,81 @@ db.biblio.class.attribute =
 
 # ======================================================================
 
+db.pubwork.enumeration =
+      ## An article
+      "article"
+    | ## A bulletin board system
+      "bbs"
+    | ## A book
+      "book"
+    | ## A CD-ROM
+      "cdrom"
+    | ## A chapter (as of a book)
+      "chapter"
+    | ## A DVD
+      "dvd"
+    | ## An email message
+      "emailmessage"
+    | ## A gopher page
+      "gopher"
+    | ## A journal
+      "journal"
+    | ## A manuscript
+      "manuscript"
+    | ## A posting to a newsgroup
+      "newsposting"
+    | ## A part (as of a book)
+      "part"
+    | ## A reference entry
+      "refentry"
+    | ## A section (as of a book or article)
+      "section"
+    | ## A series
+      "series"
+    | ## A set (as of books)
+      "set"
+    | ## A web page
+      "webpage"
+    | ## A wiki page
+      "wiki"
+    | ## Some other kind of work
+      "other"
+
+# ======================================================================
+
+ctrl:other-attribute [ name="db.biblio.pubwork.attribute"
+                       enum-name="db.biblio.pubwork-enum.attribute"
+                       other-name="db.biblio.pubwork-other.attributes" ]
+
+db.biblio.pubwork.enumeration = db.pubwork.enumeration
+
+db.biblio.pubwork-enum.attribute =
+   [
+      db:refpurpose [ "Identifies the nature of the published work" ]
+   ]
+   attribute pubwork { db.biblio.pubwork.enumeration } ?
+
+db.biblio.pubwork-other.attribute =
+   [
+      db:refpurpose [ "Identifies the nature of some other kind of published work" ]
+   ]
+   attribute otherpubwork { xsd:NMTOKEN }
+
+db.biblio.pubwork-other.attributes =
+   [
+      db:refpurpose [ "Identifies that this is some other kind of published work" ]
+   ]
+   attribute pubwork {
+      ## Indicates that the published work is some 'other' kind.
+      "other"
+   }
+ & db.biblio.pubwork-other.attribute
+
+db.biblio.pubwork.attribute =
+  (db.biblio.pubwork-enum.attribute | db.biblio.pubwork-other.attributes)
+
+# ======================================================================
+
 db.ubiq.inlines =
    db.inlinemediaobject
  | db.remark
@@ -4844,43 +4919,7 @@ div {
 ]
 div {
 
-   db.citetitle.pubwork.enumeration =
-      ## An article
-      "article"
-    | ## A bulletin board system
-      "bbs"
-    | ## A book
-      "book"
-    | ## A CD-ROM
-      "cdrom"
-    | ## A chapter (as of a book)
-      "chapter"
-    | ## A DVD
-      "dvd"
-    | ## An email message
-      "emailmessage"
-    | ## A gopher page
-      "gopher"
-    | ## A journal
-      "journal"
-    | ## A manuscript
-      "manuscript"
-    | ## A posting to a newsgroup
-      "newsposting"
-    | ## A part (as of a book)
-      "part"
-    | ## A reference entry
-      "refentry"
-    | ## A section (as of a book or article)
-      "section"
-    | ## A series
-      "series"
-    | ## A set (as of books)
-      "set"
-    | ## A web page
-      "webpage"
-    | ## A wiki page
-      "wiki"
+   db.citetitle.pubwork.enumeration = db.pubwork.enumeration
 
    db.citetitle.pubwork.attribute =
       [

--- a/src/test/docbook/fail/bibliography.001.xml
+++ b/src/test/docbook/fail/bibliography.001.xml
@@ -1,0 +1,64 @@
+<bibliography xmlns="http://docbook.org/ns/docbook" version="5.2">
+<info>
+<title>Unit Test: bibliography.001</title>
+</info>
+
+<biblioentry pubwork="book">
+  <abbrev>AhoSethiUllman96</abbrev>
+  <authorgroup>
+    <author><personname><firstname>Alfred V.</firstname><surname>Aho</surname></personname></author>
+    <author><personname><firstname>Ravi</firstname><surname>Sethi</surname></personname></author>
+    <author><personname><firstname>Jeffrey D.</firstname><surname>Ullman</surname></personname></author>
+  </authorgroup>
+  <title>Compilers, Principles, Techniques, and Tools</title>
+  <publisher>
+    <publishername>Addison-Wesley Publishing Company</publishername>
+  </publisher>
+  <copyright><year>1996</year>
+             <holder>Bell Telephone Laboratories, Inc.</holder></copyright>
+  <biblioid class="isbn">0-201-10088-6</biblioid>
+  <editor><personname><firstname>James T.</firstname><surname>DeWolf</surname></personname></editor>
+</biblioentry>
+
+<biblioentry xml:id="Walsh97" pubwork="article">
+  <abbrev>Walsh97</abbrev>
+  <biblioset relation="article">
+    <title>A Guide to XML</title>
+    <author><personname><surname>Walsh</surname><firstname>Norman</firstname></personname></author>
+    <pubdate>1997</pubdate>
+    <copyright><year>1997</year><holder>ArborText, Inc.</holder></copyright>
+    <pagenums>97-108</pagenums>
+  </biblioset>
+  <biblioset relation="journal">
+    <title>XML: Principles, Tools, and Techniques</title>
+    <publisher>
+      <publishername>O'Reilly &amp; Associates, Inc.</publishername>
+    </publisher>
+    <biblioid class="issn">1085-2301</biblioid>
+    <editor><personname><firstname>Dan</firstname><surname>Connolly</surname></personname></editor>
+  </biblioset>
+</biblioentry>
+
+<bibliomixed xml:id="Walsh96" pubwork="article">
+  <bibliomset relation="article">
+    <personname><surname>Walsh</surname></personname>, <personname><firstname>Norman</firstname></personname>.
+    <title role="article">Introduction to Cascading Style Sheets</title>.
+  </bibliomset>
+  <bibliomset relation="journal">
+    <title>The World Wide Web Journal</title>.
+    <volumenum>2</volumenum>(<issuenum>1</issuenum>).
+    <publishername>O'Reilly &amp; Associates, Inc.</publishername> and
+    <orgname>The World Wide Web Consortium</orgname>.
+    <pubdate>Winter, 1996</pubdate></bibliomset>.
+</bibliomixed>
+
+<biblioentry pubwork='other' otherpubwork='app'>
+  <title>Some App</title>
+</biblioentry>
+
+<bibliomixed pubwork='other' otherpubwork='app'>
+  <citetitle>Some App</citetitle>
+</bibliomixed>
+
+</bibliography>
+

--- a/src/test/docbook/fail/bibliography.002.xml
+++ b/src/test/docbook/fail/bibliography.002.xml
@@ -1,0 +1,11 @@
+<bibliography xmlns="http://docbook.org/ns/docbook" version="5.2">
+<info>
+<title>Unit Test: bibliography.001</title>
+</info>
+
+<biblioentry pubwork='book' otherpubwork="app">
+  <title>Some App</title>
+</biblioentry>
+
+</bibliography>
+

--- a/src/test/docbook/pass/bibliography.007.xml
+++ b/src/test/docbook/pass/bibliography.007.xml
@@ -1,0 +1,64 @@
+<bibliography xmlns="http://docbook.org/ns/docbook" version="5.2">
+<info>
+<title>Unit Test: bibliography.001</title>
+</info>
+
+<biblioentry pubwork="book">
+  <abbrev>AhoSethiUllman96</abbrev>
+  <authorgroup>
+    <author><personname><firstname>Alfred V.</firstname><surname>Aho</surname></personname></author>
+    <author><personname><firstname>Ravi</firstname><surname>Sethi</surname></personname></author>
+    <author><personname><firstname>Jeffrey D.</firstname><surname>Ullman</surname></personname></author>
+  </authorgroup>
+  <title>Compilers, Principles, Techniques, and Tools</title>
+  <publisher>
+    <publishername>Addison-Wesley Publishing Company</publishername>
+  </publisher>
+  <copyright><year>1996</year>
+             <holder>Bell Telephone Laboratories, Inc.</holder></copyright>
+  <biblioid class="isbn">0-201-10088-6</biblioid>
+  <editor><personname><firstname>James T.</firstname><surname>DeWolf</surname></personname></editor>
+</biblioentry>
+
+<biblioentry xml:id="Walsh97" pubwork="article">
+  <abbrev>Walsh97</abbrev>
+  <biblioset relation="article">
+    <title>A Guide to XML</title>
+    <author><personname><surname>Walsh</surname><firstname>Norman</firstname></personname></author>
+    <pubdate>1997</pubdate>
+    <copyright><year>1997</year><holder>ArborText, Inc.</holder></copyright>
+    <pagenums>97-108</pagenums>
+  </biblioset>
+  <biblioset relation="journal">
+    <title>XML: Principles, Tools, and Techniques</title>
+    <publisher>
+      <publishername>O'Reilly &amp; Associates, Inc.</publishername>
+    </publisher>
+    <biblioid class="issn">1085-2301</biblioid>
+    <editor><personname><firstname>Dan</firstname><surname>Connolly</surname></personname></editor>
+  </biblioset>
+</biblioentry>
+
+<bibliomixed xml:id="Walsh96" pubwork="article">
+  <bibliomset relation="article">
+    <personname><surname>Walsh</surname></personname>, <personname><firstname>Norman</firstname></personname>.
+    <title role="article">Introduction to Cascading Style Sheets</title>.
+  </bibliomset>
+  <bibliomset relation="journal">
+    <title>The World Wide Web Journal</title>.
+    <volumenum>2</volumenum>(<issuenum>1</issuenum>).
+    <publishername>O'Reilly &amp; Associates, Inc.</publishername> and
+    <orgname>The World Wide Web Consortium</orgname>.
+    <pubdate>Winter, 1996</pubdate></bibliomset>.
+</bibliomixed>
+
+<biblioentry pubwork='other' otherpubwork='app'>
+  <title>Some App</title>
+</biblioentry>
+
+<bibliomixed pubwork='other' otherpubwork='app'>
+  <citetitle>Some App</citetitle>
+</bibliomixed>
+
+</bibliography>
+


### PR DESCRIPTION
Reorganized the `pubwork` patterns to support `pubwork`/`otherpubwork` on `biblioentry` and `bibliomixed`.

Fix #164 