### PR TITLE
Add a type attribute to formal and informal objects

### DIFF
--- a/src/main/relaxng/docbook/calstbl.rnc
+++ b/src/main/relaxng/docbook/calstbl.rnc
@@ -612,8 +612,15 @@ div {
    db.cals.table.role.attribute = attribute role { text }
    db.cals.table.label.attribute = db.label.attribute
 
+   db.cals.table.type.attribute =
+      [
+         db:refpurpose [ "Identifies the type of table" ]
+      ]
+      attribute type { text }?
+
    db.cals.table.attlist =
       db.cals.table.role.attribute?
+    & db.cals.table.type.attribute?
     & db.cals.table.label.attribute?
     & db.common.attributes
     & db.common.linking.attributes
@@ -663,8 +670,15 @@ div {
 
    db.cals.informaltable.role.attribute = attribute role { text }
 
+   db.cals.informaltable.type.attribute =
+      [
+         db:refpurpose [ "Identifies the type of table" ]
+      ]
+      attribute type { text }?
+
    db.cals.informaltable.attlist =
       db.cals.informaltable.role.attribute?
+    & db.cals.informaltable.type.attribute?
     & db.common.attributes
     & db.common.linking.attributes
     & db.tabstyle.attribute?

--- a/src/main/relaxng/docbook/htmltbl.rnc
+++ b/src/main/relaxng/docbook/htmltbl.rnc
@@ -250,10 +250,17 @@ div {
    db.html.table.role.attribute = attribute role { text }
    db.html.table.label.attribute = db.label.attribute
 
+   db.html.table.type.attribute =
+      [
+         db:refpurpose [ "Identifies the type of table" ]
+      ]
+      attribute type { text }?
+
    db.html.table.attlist =
       db.html.attrs
     & db.html.table.attributes
     & db.html.table.role.attribute?
+    & db.html.table.type.attribute?
     & db.html.table.label.attribute?
     & db.orient.attribute?
     & db.pgwide.attribute?
@@ -277,10 +284,17 @@ div {
    db.html.informaltable.role.attribute = attribute role { text }
    db.html.informaltable.label.attribute = db.label.attribute
 
+   db.html.informaltable.type.attribute =
+      [
+         db:refpurpose [ "Identifies the type of table" ]
+      ]
+      attribute type { text }?
+
    db.html.informaltable.attlist =
       db.html.attrs
     & db.html.table.attributes
     & db.html.informaltable.role.attribute?
+    & db.html.informaltable.type.attribute?
     & db.html.informaltable.label.attribute?
     & db.orient.attribute?
     & db.pgwide.attribute?

--- a/src/main/relaxng/docbook/math.rnc
+++ b/src/main/relaxng/docbook/math.rnc
@@ -30,8 +30,15 @@ div {
    db.equation.role.attribute = attribute role { text }
    db.equation.label.attribute = db.label.attribute
 
+   db.equation.type.attribute =
+      [
+         db:refpurpose [ "Identifies the type of equation" ]
+      ]
+      attribute type { text }?
+
    db.equation.attlist =
       db.equation.role.attribute?
+    & db.equation.type.attribute?
     & db.common.attributes
     & db.common.linking.attributes
     & db.equation.label.attribute?
@@ -60,8 +67,15 @@ div {
 
    db.informalequation.role.attribute = attribute role { text }
 
+   db.informalequation.type.attribute =
+      [
+         db:refpurpose [ "Identifies the type of equation" ]
+      ]
+      attribute type { text }?
+
    db.informalequation.attlist =
       db.informalequation.role.attribute?
+    & db.informalequation.type.attribute?
     & db.common.attributes
     & db.common.linking.attributes
     & db.pgwide.attribute?

--- a/src/main/relaxng/docbook/pool.rnc
+++ b/src/main/relaxng/docbook/pool.rnc
@@ -1210,8 +1210,15 @@ div {
 
    db.procedure.role.attribute = attribute role { text }
 
+   db.procedure.type.attribute =
+      [
+         db:refpurpose [ "Identifies the type of procedure" ]
+      ]
+      attribute type { text }?
+
    db.procedure.attlist =
       db.procedure.role.attribute?
+    & db.procedure.type.attribute?
     & db.common.attributes
     & db.common.linking.attributes
 
@@ -2086,8 +2093,15 @@ div {
    db.example.pgwide.attribute = db.pgwide.attribute
    db.example.floatstyle.attribute = db.floatstyle.attribute
 
+   db.example.type.attribute =
+      [
+         db:refpurpose [ "Identifies the type of example" ]
+      ]
+      attribute type { text }?
+
    db.example.attlist =
       db.example.role.attribute?
+    & db.example.type.attribute?
     & db.common.attributes
     & db.common.linking.attributes
     & db.example.label.attribute?
@@ -2119,8 +2133,15 @@ div {
    db.informalexample.pgwide.attribute = db.pgwide.attribute
    db.informalexample.floatstyle.attribute = db.floatstyle.attribute
 
+   db.informalexample.type.attribute =
+      [
+         db:refpurpose [ "Identifies the type of example" ]
+      ]
+      attribute type { text }?
+
    db.informalexample.attlist =
       db.informalexample.role.attribute?
+    & db.informalexample.type.attribute?
     & db.common.attributes
     & db.common.linking.attributes
     & db.informalexample.floatstyle.attribute?
@@ -2244,8 +2265,15 @@ div {
    db.figure.pgwide.attribute = db.pgwide.attribute
    db.figure.floatstyle.attribute = db.floatstyle.attribute
 
+   db.figure.type.attribute =
+      [
+         db:refpurpose [ "Identifies the type of figure" ]
+      ]
+      attribute type { text }?
+
    db.figure.attlist =
       db.figure.role.attribute?
+    & db.figure.type.attribute?
     & db.common.attributes
     & db.common.linking.attributes
     & db.figure.label.attribute?
@@ -2276,8 +2304,15 @@ div {
    db.informalfigure.pgwide.attribute = db.pgwide.attribute
    db.informalfigure.floatstyle.attribute = db.floatstyle.attribute
 
+   db.informalfigure.type.attribute =
+      [
+         db:refpurpose [ "Identifies the type of figure" ]
+      ]
+      attribute type { text }?
+
    db.informalfigure.attlist =
       db.informalfigure.role.attribute?
+    & db.informalfigure.type.attribute?
     & db.common.attributes
     & db.common.linking.attributes
     & db.informalfigure.label.attribute?

--- a/src/test/docbook/pass/figtype.001.xml
+++ b/src/test/docbook/pass/figtype.001.xml
@@ -1,0 +1,176 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
+<title>Article wrapper</title>
+
+<figure xml:id="figduck" type="alpha">
+  <title>The Duck</title>
+  <mediaobject>
+    <imageobject>
+      <imagedata
+        align="center"
+        fileref="../graphics/duck-small.eps"
+        format="EPS">
+        <info>
+          <othercredit>
+            <orgname>O'Reilly &amp; Associates/Dover Archives</orgname>
+          </othercredit>
+        </info>
+      </imagedata>
+    </imageobject>
+    <textobject><phrase>The DocBook: TDG Duck</phrase></textobject>
+  </mediaobject>
+</figure>
+
+<informalfigure type="beta">
+  <mediaobject>
+    <imageobject>
+      <imagedata
+        align="center"
+        fileref="../graphics/duck-small.eps"
+        format="EPS">
+        <info>
+          <othercredit>
+            <orgname>O'Reilly &amp; Associates/Dover Archives</orgname>
+          </othercredit>
+        </info>
+      </imagedata>
+    </imageobject>
+    <textobject><phrase>The DocBook: TDG Duck</phrase></textobject>
+  </mediaobject>
+</informalfigure>
+
+<example type="gamma"><title>An Example</title>
+<programlisting>
+This is a programlisting in an example.
+</programlisting>
+</example>
+
+<informalexample type="delta">
+<programlisting>
+This is a programlisting in an example.
+</programlisting>
+</informalexample>
+
+<para>CALS:</para>
+
+<table frame="all" type="epsilon">
+<title>TFoot Test</title>
+<tgroup cols="2">
+<tfoot>
+<row>
+<entry>Foot Left</entry>
+<entry>Foot Right</entry>
+</row>
+</tfoot>
+<tbody>
+<row>
+<entry>Body Left</entry>
+<entry>Body Right</entry>
+</row>
+</tbody>
+</tgroup>
+</table>
+
+<informaltable frame="all" type="zeta">
+<tgroup cols="2">
+<tfoot>
+<row>
+<entry>Foot Left</entry>
+<entry>Foot Right</entry>
+</row>
+</tfoot>
+<tbody>
+<row>
+<entry>Body Left</entry>
+<entry>Body Right</entry>
+</row>
+</tbody>
+</tgroup>
+</informaltable>
+
+<para>HTML:</para>
+
+<table border="1" type="eta">
+<caption>TFoot Test</caption>
+<tfoot>
+<tr>
+<td>Foot Left</td>
+<td>Foot Right</td>
+</tr>
+</tfoot>
+<tbody>
+<tr>
+<td>Body Left</td>
+<td>Body Right</td>
+</tr>
+</tbody>
+</table>
+
+<informaltable border="1" type="theta">
+<tfoot>
+<tr>
+<td>Foot Left</td>
+<td>Foot Right</td>
+</tr>
+</tfoot>
+<tbody>
+<tr>
+<td>Body Left</td>
+<td>Body Right</td>
+</tr>
+</tbody>
+</informaltable>
+
+<equation type="iota"><title>First Equation</title>
+<mediaobject>
+<imageobject>
+<imagedata fileref="../graphics/emc2.png"/>
+</imageobject>
+<textobject>
+<phrase>E=mc^2</phrase>
+</textobject>
+</mediaobject>
+</equation>
+
+<informalequation type="kappa">
+<mediaobject>
+<imageobject>
+<imagedata fileref="../graphics/emc2.png"/>
+</imageobject>
+<textobject>
+<phrase>E=mc^2</phrase>
+</textobject>
+</mediaobject>
+</informalequation>
+
+<procedure xml:id="notitle" type="lambda">
+<step><para>Press MENUS.</para>
+</step>
+<step xml:id="step-x-1"><para>Press MENUS.</para>
+</step>
+<step><para>Press MENUS.</para>
+</step>
+<step><para>Press MENUS.</para>
+</step>
+<step><para>Select SETUP.</para>
+<substeps>
+<step><para>Should be an <quote>a</quote></para>
+</step>
+<step xml:id="step-y-1"><para>Should be a <quote>b</quote></para>
+</step>
+<step><para>Should be a <quote>c</quote></para>
+</step>
+<step><para>Should be a <quote>d</quote></para>
+</step>
+<step><para>should be an <quote>e</quote></para>
+<substeps>
+<step><para>should be an <quote>i</quote></para>
+</step>
+<step xml:id="step-z-1"><para>should be an <quote>ii</quote></para>
+</step>
+</substeps>
+</step>
+</substeps>
+</step>
+</procedure>
+
+</article>


### PR DESCRIPTION
Added a `type` attribute to `figure`, `informalfigure`, `table`, `informaltable`, `example`, `informalexample`, `equation`, `informalequation`, and `procedure`.

Fix #157 