### PR TITLE
Fix #150 by implementing legalsection as a class attribute

### DIFF
--- a/src/main/relaxng/docbook/hier.rnc
+++ b/src/main/relaxng/docbook/hier.rnc
@@ -5,7 +5,7 @@ namespace db = "http://docbook.org/ns/docbook"
 namespace dbx = "http://sourceforge.net/projects/docbook/defguide/schema/extra-markup"
 default namespace = "http://docbook.org/ns/docbook"
 
-start |= db.partintro | db.simplesect | db.legalsection
+start |= db.partintro | db.simplesect
 
 db.status.attribute =
    [
@@ -18,12 +18,12 @@ db.status.attribute =
 
 # ======================================================================
 
-db.toplevel.sections = ((db.section|db.legalsection)+, db.simplesect*) | db.simplesect+
+db.toplevel.sections = (db.section+, db.simplesect*) | db.simplesect+
 
 db.toplevel.blocks.or.sections =
   (db.all.blocks+, db.toplevel.sections?) | db.toplevel.sections
 
-db.recursive.sections = ((db.section|db.legalsection)+, db.simplesect*) | db.simplesect+
+db.recursive.sections = (db.section+, db.simplesect*) | db.simplesect+
 
 db.recursive.blocks.or.sections =
   (db.all.blocks+, db.recursive.sections?) | db.recursive.sections
@@ -374,6 +374,39 @@ div {
 
    db.section.status.attribute = db.status.attribute
 
+   ctrl:other-attribute [ name="db.section.class.attribute"
+                          enum-name="db.section.class-enum.attribute"
+                          other-name="db.section.class-other.attributes" ]
+   
+   db.section.class.enumeration =
+      ## A section of legal obligations or requirements
+      "legal"
+
+   db.section.class-enum.attribute =
+      [
+         db:refpurpose [ "Identifies the nature of the section" ]
+      ]
+      attribute class { db.section.class.enumeration }
+
+    db.section.class-other.attribute =
+      [
+         db:refpurpose [ "Identifies a non-standard section class" ]
+      ]
+      attribute otherclass { xsd:NMTOKEN }
+
+   db.section.class-other.attributes =
+      [
+         db:refpurpose [ "Indicates that a non-standard section class is applied" ]
+      ]
+      attribute class {
+         ## Indicates that the identifier is some 'other' kind.
+         "other"
+      }
+      & db.section.class-other.attribute
+
+   db.section.class.attribute =
+     (db.section.class-enum.attribute | db.section.class-other.attributes)
+
    db.section.role.attribute = attribute role { text }
 
    db.section.attlist =
@@ -382,6 +415,7 @@ div {
     & db.common.linking.attributes
     & db.label.attribute?
     & db.section.status.attribute?
+    & db.section.class.attribute?
 
    db.section.info = db._info.title.req
 
@@ -423,32 +457,6 @@ div {
          db.all.blocks*
       }
 
-}
-# ======================================================================
-
-[
-   db:refname [ "legalsection" ]
-   db:refpurpose [ "A recursive section of legal obligations or requirements." ]
-]
-div {
-   db.legalsection.role.attribute = attribute role { text }
-
-   db.legalsection.attlist =
-      db.legalsection.role.attribute?
-    & db.common.attributes
-    & db.common.linking.attributes
-    & db.label.attribute?
-
-   db.legalsection.info = db._info.title.req
-
-   db.legalsection =
-      element legalsection {
-         db.legalsection.attlist,
-         db.legalsection.info,
-         db.all.blocks*,
-         db.legalsection*
-      }
-    
 }
 # ======================================================================
 

--- a/src/main/relaxng/docbook/sect1.rnc
+++ b/src/main/relaxng/docbook/sect1.rnc
@@ -19,6 +19,7 @@ db.sect1.sections = (db.sect2+, db.simplesect*) | db.simplesect+
 div {
 
    db.sect1.status.attribute = db.status.attribute
+   db.sect1.class.attribute = db.section.class.attribute
 
    db.sect1.role.attribute = attribute role { text }
 
@@ -28,6 +29,7 @@ div {
     & db.common.linking.attributes
     & db.label.attribute?
     & db.sect1.status.attribute?
+    & db.sect1.class.attribute?
 
    db.sect1.info = db._info.title.req
 
@@ -53,6 +55,7 @@ db.sect2.sections = (db.sect3+, db.simplesect*) | db.simplesect+
 div {
 
    db.sect2.status.attribute = db.status.attribute
+   db.sect2.class.attribute = db.section.class.attribute
 
    db.sect2.role.attribute = attribute role { text }
 
@@ -62,6 +65,7 @@ div {
     & db.common.linking.attributes
     & db.label.attribute?
     & db.sect2.status.attribute?
+    & db.sect2.class.attribute?
 
    db.sect2.info = db._info.title.req
 
@@ -87,6 +91,7 @@ db.sect3.sections = (db.sect4+, db.simplesect*) | db.simplesect+
 div {
 
    db.sect3.status.attribute = db.status.attribute
+   db.sect3.class.attribute = db.section.class.attribute
 
    db.sect3.role.attribute = attribute role { text }
 
@@ -96,6 +101,7 @@ div {
     & db.common.linking.attributes
     & db.label.attribute?
     & db.sect3.status.attribute?
+    & db.sect3.class.attribute?
 
    db.sect3.info = db._info.title.req
 
@@ -121,6 +127,7 @@ db.sect4.sections = (db.sect5+, db.simplesect*) | db.simplesect+
 div {
 
    db.sect4.status.attribute = db.status.attribute
+   db.sect4.class.attribute = db.section.class.attribute
 
    db.sect4.role.attribute = attribute role { text }
 
@@ -130,6 +137,7 @@ div {
     & db.common.linking.attributes
     & db.label.attribute?
     & db.sect4.status.attribute?
+    & db.sect4.class.attribute?
 
    db.sect4.info = db._info.title.req
 
@@ -155,6 +163,7 @@ db.sect5.sections = db.simplesect+
 div {
 
    db.sect5.status.attribute = db.status.attribute
+   db.sect5.class.attribute = db.section.class.attribute
 
    db.sect5.role.attribute = attribute role { text }
 
@@ -164,6 +173,7 @@ div {
     & db.common.linking.attributes
     & db.label.attribute?
     & db.sect5.status.attribute?
+    & db.sect5.class.attribute?
 
    db.sect5.info = db._info.title.req
 

--- a/src/main/relaxng/publishers/publishers.rnc
+++ b/src/main/relaxng/publishers/publishers.rnc
@@ -223,7 +223,6 @@ div {
   db.keycode = notAllowed
   db.keycombo = notAllowed
   db.keysym = notAllowed
-  db.legalsection = notAllowed
   db.lhs = notAllowed
   db.lineannotation = notAllowed
   db.locator = notAllowed
@@ -290,7 +289,6 @@ div {
   db.sect3 = notAllowed
   db.sect4 = notAllowed
   db.sect5 = notAllowed
-  db.legalsection = notAllowed
   db.seealsoie = notAllowed
   db.seeie = notAllowed
   db.seg = notAllowed

--- a/src/main/relaxng/sdocbook/sdocbook.rnc
+++ b/src/main/relaxng/sdocbook/sdocbook.rnc
@@ -20,8 +20,6 @@ include "../docbook/hier.rnc" {
    db.colophon = notAllowed
    db.dedication = notAllowed
 
-   db.legalsection = notAllowed
-
    [
       db:refname [ "article" ]
       db:refpurpose [ "An article" ]

--- a/src/test/docbook/fail/sect1.001.xml
+++ b/src/test/docbook/fail/sect1.001.xml
@@ -1,0 +1,11 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
+<title>Invalid section class</title>
+
+<sect1 class="none">
+<title>No class</title>
+<para>This section has no class. Well. Technically, it has a class of
+“none” which is probably not quite the same thing. It’s also not valid.
+</para>
+</sect1>
+
+</article>

--- a/src/test/docbook/fail/sect1.002.xml
+++ b/src/test/docbook/fail/sect1.002.xml
@@ -1,0 +1,9 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
+<title>Unspecified other class</title>
+
+<sect1 class="other">
+<title>Other class</title>
+<para>This section fails to identify its other class.</para>
+</sect1>
+
+</article>

--- a/src/test/docbook/fail/sect2.001.xml
+++ b/src/test/docbook/fail/sect2.001.xml
@@ -1,0 +1,13 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
+<title>Unspecified other class</title>
+
+<sect1>
+<title>This is a top-level section</title>
+
+<sect2 class="other">
+<title>Other class</title>
+<para>This section fails to identify its other class.</para>
+</sect2>
+</sect1>
+
+</article>

--- a/src/test/docbook/fail/section.001.xml
+++ b/src/test/docbook/fail/section.001.xml
@@ -1,0 +1,11 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
+<title>Invalid section class</title>
+
+<section class="none">
+<title>No class</title>
+<para>This section has no class. Well. Technically, it has a class of
+“none” which is probably not quite the same thing. It’s also not valid.
+</para>
+</section>
+
+</article>

--- a/src/test/docbook/fail/section.002.xml
+++ b/src/test/docbook/fail/section.002.xml
@@ -1,0 +1,9 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
+<title>Unspecified other class</title>
+
+<section class="other">
+<title>Other class</title>
+<para>This section fails to identify its other class.</para>
+</section>
+
+</article>

--- a/src/test/docbook/pass/sect1.003.xml
+++ b/src/test/docbook/pass/sect1.003.xml
@@ -1,0 +1,22 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
+<info>
+  <title>Unit Test: sect1.003</title>
+  <subtitle>Sections with a class attribute</subtitle>
+</info>
+
+<sect1 class="legal">
+  <title>This is a “legal” section.</title>
+  <para>So sue me. (No, I’m just kidding, please don’t.)</para>
+
+  <sect2>
+    <title>A “normal” section</title>
+    <para>What, me normal?</para>
+
+    <sect3 class="other" otherclass="sparkly">
+      <title>This section sparkles</title>
+      <para>Scintillating!</para>
+    </sect3>
+  </sect2>
+</sect1>
+
+</article>

--- a/src/test/docbook/pass/section.006.xml
+++ b/src/test/docbook/pass/section.006.xml
@@ -1,0 +1,22 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
+<info>
+  <title>Unit Test: section.006</title>
+  <subtitle>Sections with a class attribute</subtitle>
+</info>
+
+<section class="legal">
+  <title>This is a “legal” section.</title>
+  <para>So sue me. (No, I’m just kidding, please don’t.)</para>
+</section>
+
+<section>
+  <title>A “normal” section</title>
+  <para>What, me normal?</para>
+</section>
+
+<section class="other" otherclass="sparkly">
+  <title>This section sparkles</title>
+  <para>Scintillating!</para>
+</section>
+
+</article>


### PR DESCRIPTION
1. Remove `legalsection` element
2. Add `class` and `otherclass` attributes to section elements

There's no explicit `class` for "ordinary section" but perhaps that's okay.