### PR TITLE
Fix #163 by adding the transclusion attributes as common attributes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.daemon=false
 org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
-saxonVersion=9.9.1.8
+saxonVersion=9.9.1-8
 dbver = 5.2b10a4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.daemon=false
 org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
-saxonVersion=9.9.1-7
-dbver = 5.2b10a3
+saxonVersion=9.9.1.8
+dbver = 5.2b10a4

--- a/src/main/relaxng/docbook/pool.rnc
+++ b/src/main/relaxng/docbook/pool.rnc
@@ -4,6 +4,7 @@ namespace s = "http://purl.oclc.org/dsdl/schematron"
 namespace db = "http://docbook.org/ns/docbook"
 namespace dbx = "http://sourceforge.net/projects/docbook/defguide/schema/extra-markup"
 namespace xlink = "http://www.w3.org/1999/xlink"
+namespace trans = "http://docbook.org/ns/transclusion"
 namespace html = "http://www.w3.org/1999/xhtml"
 namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 default namespace = "http://docbook.org/ns/docbook"
@@ -389,6 +390,57 @@ db.rdfalite.attributes =
  & db.rdfalite.resource?
  & db.rdfalite.prefix?
 
+db.trans.idfixup.enumeration =
+   ## No ID fixup strategy
+   "none"
+ | ## ID fixup by concatenating suffixes
+   "suffix"
+ | ## ID fixup by creating unique values
+   "auto"
+
+db.trans.idfixup.attribute =
+   [
+      db:refpurpose [ "The transclusion ID fixup strategy" ]
+   ]
+   attribute trans:idfixup { db.trans.idfixup.enumeration }
+
+db.trans.suffix.attribute =
+   [
+      db:refpurpose [ "The transclusion suffix to use when the suffix ID fixup strategy is employed" ]
+      s:pattern [
+         s:title [ "Suffix fixup must be specified" ]
+         s:rule [
+            context = "db:*[@trans:suffix]"
+            s:assert [
+               test = "@trans:idfixup = 'suffix'"
+               "If a suffix is specified, suffix ID fixup must also be specified."
+            ]
+         ]
+      ]
+   ]
+   attribute trans:suffix { text }
+
+db.trans.linkscope.enumeration =
+   ## No link scope adjustments are made
+   "user"
+ | ## The link scopes are adjusted with the suffix property
+   "local"
+ | ## The link scopes are adjusted based on proximity
+   "near"
+ | ## The link scopes are adjusted based on document order
+   "global"
+
+db.trans.linkscope.attribute =
+   [
+      db:refpurpose [ "The transclusion link scope adjustment" ]
+   ]
+   attribute trans:linkscope { db.trans.linkscope.enumeration }
+
+db.common.transclusion.attributes =
+   db.trans.idfixup.attribute?
+ & db.trans.suffix.attribute?
+ & db.trans.linkscope.attribute?
+
 db.common.base.attributes =
    db.version.attribute?
  & db.xml.lang.attribute?
@@ -399,6 +451,7 @@ db.common.base.attributes =
  & db.dir.attribute?
  & db.effectivity.attributes
  & db.rdfalite.attributes
+ & db.common.transclusion.attributes
 
 db.common.attributes =
    db.xml.id.attribute?

--- a/src/test/docbook/fail/trans.001.xml
+++ b/src/test/docbook/fail/trans.001.xml
@@ -1,0 +1,11 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0"
+         xmlns:trans="http://docbook.org/ns/transclusion">
+<info>
+<title>Unit Test: trans.001.xml</title>
+</info>
+
+<para>This article tests transclusion attributes.</para>
+
+<para trans:idfixup="wrong">The trans:idfixup value is invalid.</para>
+
+</article>

--- a/src/test/docbook/fail/trans.002.xml
+++ b/src/test/docbook/fail/trans.002.xml
@@ -1,0 +1,9 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0"
+         xmlns:trans="http://docbook.org/ns/transclusion">
+<info>
+<title>Unit Test: trans.001.xml</title>
+</info>
+
+<para trans:linkscope="wrong">The trans:linkscope value is invalid.</para>
+
+</article>

--- a/src/test/docbook/fail/trans.003.xml
+++ b/src/test/docbook/fail/trans.003.xml
@@ -1,0 +1,11 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0"
+         xmlns:trans="http://docbook.org/ns/transclusion">
+<info>
+<title>Unit Test: trans.004.xml</title>
+</info>
+
+<para>This article tests transclusion attributes.</para>
+
+<para trans:suffix="sfx">Error: trans:idfixup is missing.</para>
+
+</article>

--- a/src/test/docbook/fail/trans.004.xml
+++ b/src/test/docbook/fail/trans.004.xml
@@ -1,0 +1,11 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0"
+         xmlns:trans="http://docbook.org/ns/transclusion">
+<info>
+<title>Unit Test: trans.004.xml</title>
+</info>
+
+<para>This article tests transclusion attributes.</para>
+
+<para trans:idfixup="none" trans:suffix="sfx">Error: trans:idfixup is not suffix.</para>
+
+</article>

--- a/src/test/docbook/pass/trans.001.xml
+++ b/src/test/docbook/pass/trans.001.xml
@@ -1,0 +1,25 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0"
+         xmlns:trans="http://docbook.org/ns/transclusion">
+<info>
+<title>Unit Test: trans.001.xml</title>
+</info>
+
+<para>This article tests transclusion attributes.</para>
+
+<para trans:idfixup="none"/>
+
+<para trans:idfixup="suffix"/>
+
+<para trans:idfixup="auto"/>
+
+<para trans:idfixup="suffix" trans:suffix="sfx"/>
+
+<para trans:linkscope="user"/>
+
+<para trans:linkscope="local"/>
+
+<para trans:linkscope="near"/>
+
+<para trans:linkscope="global"/>
+
+</article>

--- a/tools/schematron.xsl
+++ b/tools/schematron.xsl
@@ -12,6 +12,7 @@
     <s:schema>
       <s:ns prefix="db" uri="http://docbook.org/ns/docbook"/>
       <s:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+      <s:ns prefix="trans" uri="http://docbook.org/ns/transclusion"/>
 
       <xsl:for-each-group select="//s:pattern" group-by="s:title">
 	<xsl:sort data-type="text" order="ascending"/>


### PR DESCRIPTION
That should make them available in all of the DocBook-related schemas.