### PR TITLE
Remove templatename from Simplified DocBook

### DIFF
--- a/src/main/relaxng/sdocbook/sdocbook.rnc
+++ b/src/main/relaxng/sdocbook/sdocbook.rnc
@@ -120,6 +120,7 @@ include "../docbook/programming.rnc" {
    db.type = notAllowed
   db.synopsisinfo = notAllowed
   db.templateid = notAllowed
+  db.templatename = notAllowed
   db.specializedtemplate = notAllowed
   db.template = notAllowed
   db.namespace = notAllowed


### PR DESCRIPTION
It should be excluded.