### PR TITLE
Remove duplicated reference to enumsynopsis

### DIFF
--- a/src/main/relaxng/docbook/programming.rnc
+++ b/src/main/relaxng/docbook/programming.rnc
@@ -58,7 +58,6 @@ db.synopsis.blocks =
  | db.namespacesynopsis
  | db.macrosynopsis
  | db.unionsynopsis
- | db.enumsynopsis
  | db.typedefsynopsis
 
 db.programmingsynopsis =


### PR DESCRIPTION
The `db.enumsynopsis` pattern was unnecessarily included twice in the `db.synopsis.blocks` pattern.