### PR TITLE
Preserve build artifacts on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,9 @@ jobs:
           paths:
             - distributions
 
+      - store_artifacts:
+          path: build
+
   deploybuild:
     machine:
       image: ubuntu-1604:202004-01


### PR DESCRIPTION
Tweak the CircleCI build so that it preserves build artifacts. This will allow us to review them later.