### PR TITLE
Remove dangling reference to instance attribute

### DIFF
--- a/src/main/relaxng/assembly/assembly-core.rnc
+++ b/src/main/relaxng/assembly/assembly-core.rnc
@@ -412,7 +412,6 @@ div {
    db.relationships.attlist =
       db.relationships.role.attribute?
     & db.relationships.type.attribute?
-    & db.relationships.instance.attribute?
     & db.common.attributes
 
    db.relationships.info = db._info


### PR DESCRIPTION
The assembly schema included a dangling reference to an `instance` attribute. It's possibly been there a long time, but recent changes to `include.xsl` flushed it out.