### PR TITLE
Fix #206 by making the name attribute optional on meta

### DIFF
--- a/src/docbook/relaxng/docbook/pool.rnc
+++ b/src/docbook/relaxng/docbook/pool.rnc
@@ -4673,7 +4673,7 @@ div {
       attribute content { text }
 
    db.meta.attlist =
-      db.meta.name.attribute
+      db.meta.name.attribute?
     & db.meta.role.attribute?
     & db.common.attributes
     & db.common.linking.attributes


### PR DESCRIPTION
Requiring name makes it parallel with HTML, but forces users who want to leverage `meta` for RDFa or other purposes into dealing with a required attribute they don't need. This PR makes it optional.