### PR TITLE
Generate catalog file entries for the official OASIS locations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -431,15 +431,29 @@ distributions.each { dist, obj ->
 
   task "${dist}_catalog"(type: SaxonXsltTask, dependsOn: ["${dist}_stage"]) {
     def path = "${buildDir}/stage/${dist}-${dbver}"
+
+    def catalogParameters = [
+      'title': "XML Catalog for ${titles[dist]}",
+      'version': dbver,
+      'distribution': dist,
+      'uris': "${buildDir}/tmp/${dist}.uris"
+    ]
+
+    if (dist == "docbook") {
+      catalogParameters['oasisVersion'] = oasisDocBookVersion
+      catalogParameters['oasisRelease'] = oasisDocBookRelease
+    }
+
+    if (dist == "publishers") {
+      catalogParameters['oasisVersion'] = oasisPublishersVersion
+      catalogParameters['oasisRelease'] = oasisPublishersRelease
+    }
+
     inputs.file("tools/catalog.xsl")
     input "tools/catalog.xsl"
     output "${path}/catalog.xml"
     stylesheet "tools/catalog.xsl"
-    parameters (
-      "version-list": "${dbver} ${nextReleaseVer}",
-      "distribution": dist,
-      "uris": "${buildDir}/tmp/${dist}.uris"
-    )
+    parameters catalogParameters
   }
 
   task "${dist}_zip"(type: Zip, dependsOn: ["${dist}_catalog"]) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,9 @@ systemProp.javax.xml.transform.TransformerFactory=net.sf.saxon.TransformerFactor
 saxonVersion = 9.9.1-8
 resolverVersion = 3.0.1beta1
 dbver = 5.2b10a4
+
+oasisDocBookVersion=5.2
+oasisDocBookRelease=wd01
+
+oasisPublishersVersion=
+oasisPublishersRelease=

--- a/tools/catalog.xsl
+++ b/tools/catalog.xsl
@@ -1,100 +1,82 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" 
                 exclude-result-prefixes="xs"
                 version="2.0">
 
 <xsl:output method="xml" encoding="utf-8" indent="yes"/>
 
-<xsl:param name="version-list" as="xs:string" required="yes"/>
-<xsl:param name="distribution" as="xs:string" required="yes"/>
+<xsl:param name="title" as="xs:string" select="'XML Catalog'"/>
+<xsl:param name="version" as="xs:string" select="'UNKNOWN'"/>
+<xsl:param name="oasisVersion" as="xs:string" select="''"/>
+<xsl:param name="oasisRelease" as="xs:string" select="''"/>
 <xsl:param name="uris" as="xs:string" required="yes"/>
 
-<xsl:variable name="versions" select="distinct-values(tokenize($version-list, '\s+'))"/>
+<xsl:variable name="files"
+              select="tokenize(normalize-space(unparsed-text($uris)), '\s+')
+                      [. != 'catalog.xml']"/>
 
 <xsl:template match="/">
-  <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
+  <xsl:variable name="dots" select="'...........................................................'"/>
+
+  <catalog prefer="public">
     <xsl:text>&#10;</xsl:text>
     <xsl:comment> ............................................................ </xsl:comment>
     <xsl:text>&#10;</xsl:text>
-    <xsl:comment> XML Catalog for DocBook .................................... </xsl:comment>
-    <xsl:text>&#10;</xsl:text>
-    <xsl:comment> File catalog.xml ........................................... </xsl:comment>
+    <xsl:comment>
+      <xsl:sequence select="concat(' ', $title, ' ',
+                                   substring($dots, 1, string-length($dots) - string-length($title)),
+                                   ' ')"/>
+    </xsl:comment>
     <xsl:text>&#10;</xsl:text>
     <xsl:text>&#10;</xsl:text>
     <xsl:comment>
- Please direct all questions, bug reports, or suggestions for
- changes to the docbook-comment@lists.oasis-open.org mailing list.
- For more information, see http://www.oasis-open.org/.
+ Please direct all questions, bug reports, or suggestions for changes
+ to the docbook-comment@lists.oasis-open.org mailing list. For more
+ information, see http://www.oasis-open.org/.
 </xsl:comment>
     <xsl:text>&#10;</xsl:text>
     <xsl:text>&#10;</xsl:text>
     <xsl:comment>
- This is a catalog data file for DocBook. It is provided as a
- convenience in building your own catalog files. You need not
- use the filenames listed here, and need not use the filename
- method of identifying storage objects at all. See the
- documentation for detailed information on the files associated
- with the DocBook DTD. See XML Catalogs at
- http://www.oasis-open.org/committees/entity/ for detailed
+ This is an OASIS XML Catalog file. It is provided as a convenience in
+ building your own catalog files. You need not use the filenames
+ listed here, and need not use the filename method of identifying
+ storage objects at all. See the documentation for detailed
+ information on the files associated with the DocBook DTD. See XML
+ Catalogs at http://www.oasis-open.org/committees/entity/ for detailed
  information on supplying and using catalog data.
 </xsl:comment>
     <xsl:text>&#10;</xsl:text>
+    <xsl:comment> ............................................................ </xsl:comment>
     <xsl:text>&#10;</xsl:text>
 
-    <xsl:for-each select="$versions">
-      <xsl:variable name="version" select="."/>
-      <xsl:variable name="paths" as="xs:string*">
-        <xsl:choose>
-          <xsl:when test="$distribution = 'docbook'">
-            <xsl:sequence select="('www.oasis-open.org/docbook/xml/v' || $version,
-                                  'docbook.org/xml/' || $version,
-                                  'www.docbook.org/xml/' || $version,
-                                  'cdn.docbook.org/schema/' || $version,
-                                  'cdn.docbook.org/schema/docbook-' || $version)"/>
-          </xsl:when>
-          <xsl:when test="$distribution = 'publishers'">
-            <xsl:sequence select="('www.oasis-open.org/docbook/xml/publishers/v' || $version,
-                                  'docbook.org/xml/publishers/' || $version,
-                                  'www.docbook.org/xml/publishers/' || $version,
-                                  'cdn.docbook.org/schema/publishers-'||$version)"/>
-          </xsl:when>
-          <xsl:when test="$distribution = 'sdocbook'">
-            <xsl:sequence select="('docbook.org/xml/website/' || $version,
-                                  'www.docbook.org/xml/website/' || $version,
-                                  'cdn.docbook.org/schema/website-'||$version)"/>
-          </xsl:when>
-          <xsl:when test="$distribution = 'website'">
-            <xsl:sequence select="('docbook.org/xml/website/' || $version,
-                                  'www.docbook.org/xml/website/' || $version,
-                                  'cdn.docbook.org/schema/website-'||$version)"/>
-          </xsl:when>
-          <xsl:when test="$distribution = 'slides'">
-            <xsl:sequence select="('docbook.org/xml/slides/' || $version,
-                                  'www.docbook.org/xml/slides/' || $version,
-                                  'cdn.docbook.org/schema/slides-'||$version)"/>
-          </xsl:when>
-          <xsl:when test="$distribution = 'dbforms'">
-            <xsl:sequence select="('docbook.org/xml/htmlforms/' || $version,
-                                  'www.docbook.org/xml/htmlforms/' || $version,
-                                  'cdn.docbook.org/schema/htmlforms-'||$version)"/>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:message terminate="yes"
-                         select="'Unknown distribution: ' || $distribution"/>
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:variable>
+    <xsl:if test="$oasisVersion != '' and $oasisRelease != ''">
+      <xsl:call-template name="catalog-files">
+        <xsl:with-param name="comment" select="'The official OASIS URIs'"/>
+        <xsl:with-param name="root"
+                        select="concat('docs.oasis-open.org/docbook/docbook/v',
+                                       $oasisVersion, '/', $oasisRelease)"/>
+      </xsl:call-template>
+    </xsl:if>
 
-      <xsl:for-each select="$paths">
-        <xsl:variable name="root" select="."/>
-        <xsl:for-each select="tokenize(unparsed-text($uris), '\s+')">
-          <xsl:if test="normalize-space(.) != ''">
-            <uri name="https://{$root}/{.}" uri="{.}"/>
-          </xsl:if>
-        </xsl:for-each>
-      </xsl:for-each>
-    </xsl:for-each>
+    <xsl:call-template name="catalog-files">
+      <xsl:with-param name="comment" select="'The historical OASIS URIs (for backwards compatibility)'"/>
+      <xsl:with-param name="root"
+                      select="concat('www.oasis-open.org/docbook/xml/', $version)"/>
+    </xsl:call-template>
+
+    <xsl:call-template name="catalog-files">
+      <xsl:with-param name="comment" select="'The docbook.org URIs'"/>
+      <xsl:with-param name="root"
+                      select="concat('docbook.org/xml/', $version)"/>
+    </xsl:call-template>
+
+    <xsl:call-template name="catalog-files">
+      <xsl:with-param name="comment" select="'The www.docbook.org URIs (for completeness)'"/>
+      <xsl:with-param name="root"
+                      select="concat('www.docbook.org/xml/', $version)"/>
+    </xsl:call-template>
   </catalog>
 </xsl:template>
 
@@ -106,6 +88,28 @@
 
 <xsl:template match="attribute()|text()|comment()|processing-instruction()">
   <xsl:copy/>
+</xsl:template>
+
+<xsl:template name="catalog-files">
+  <xsl:param name="comment" as="xs:string" required="yes"/>
+  <xsl:param name="root" as="xs:string" required="yes"/>
+
+  <xsl:for-each select="('https', 'http')">
+    <group>
+      <xsl:text> </xsl:text>
+      <xsl:comment>
+        <xsl:text> </xsl:text>
+        <xsl:sequence select="concat($comment, ', ', .)"/>
+        <xsl:text> </xsl:text>
+      </xsl:comment>
+      <xsl:text>&#10;</xsl:text>
+
+      <xsl:variable name="scheme" select="."/>
+      <xsl:for-each select="$files">
+        <uri name="{$scheme}://{$root}/{.}" uri="{.}"/>
+      </xsl:for-each>
+    </group>
+  </xsl:for-each>
 </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
This PR changes the way catalog files are created so that the official OASIS URIs appear in the catalogs. It is substantially the same as #202 but refactored because of unrelated changes to the build process.

Close #202.
