### PR TITLE
Make use of synopsisinfo more uniform

### DIFF
--- a/src/docbook/relaxng/docbook/programming.rnc
+++ b/src/docbook/relaxng/docbook/programming.rnc
@@ -605,10 +605,12 @@ div {
       element fieldsynopsis {
          db.fieldsynopsis.attlist,
          db.fieldsynopsis.info,
+         db.synopsisinfo*,
          db.modifier*,
          (db.type | db.templatename)*,
          db.varname,
-         db.initializer?
+         db.initializer?,
+         db.synopsisinfo*
       }
 }
 
@@ -657,10 +659,12 @@ div {
       element constructorsynopsis {
          db.constructorsynopsis.attlist,
          db.constructorsynopsis.info,
+         db.synopsisinfo*
          db.modifier*,
          db.methodname?,
          ((db.methodparam|db.group.methodparam)+ | db.void?),
-         db.exceptionname*
+         db.exceptionname*,
+         db.synopsisinfo*
       }
 }
 
@@ -685,10 +689,12 @@ div {
       element destructorsynopsis {
          db.destructorsynopsis.attlist,
          db.destructorsynopsis.info,
+         db.synopsisinfo*
          db.modifier*,
          db.methodname?,
          ((db.methodparam|db.group.methodparam)+ | db.void?),
-         db.exceptionname*
+         db.exceptionname*,
+         db.synopsisinfo*
       }
 }
 

--- a/src/docbook/relaxng/docbook/programming.rnc
+++ b/src/docbook/relaxng/docbook/programming.rnc
@@ -58,7 +58,6 @@ db.synopsis.blocks =
  | db.namespacesynopsis
  | db.macrosynopsis
  | db.unionsynopsis
- | db.typedefsynopsis
 
 db.programmingsynopsis =
    db.namespacesynopsis


### PR DESCRIPTION
In 5.2b10a4, the `synopsisinfo` element occurs in `methodsynopsis` but not in any of the related synopses. This PR fixes that, adding it to `constructorsynopsis`, `destructorsynopsis`, and `fieldsynopsis`.

The `synopsisinfo` element is also missing from `cmdsynopsis`, but that has a different structure and an existing cross reference mechanism, so it isn't clear (to me) that `synopsisinfo` would be practical there.

Close #200 which has merge conflicts.