### PR TITLE
Allow db:modifier after db:methodname and the parameters in db:constructorsynopsis

### DIFF
--- a/src/docbook/relaxng/docbook/programming.rnc
+++ b/src/docbook/relaxng/docbook/programming.rnc
@@ -681,6 +681,7 @@ div {
          db.modifier*,
          db.methodname?,
          ((db.methodparam|db.group.methodparam)+ | db.void?),
+         db.modifier*,
          db.exceptionname*,
          db.synopsisinfo*
       }


### PR DESCRIPTION
This allows the description to match more language syntaxes, like C++. My use case is the following: 

```xml
<db:constructorsynopsis>
<db:methodname>QXmlStreamWriter</db:methodname>
<db:methodparam>
<db:type>QString *</db:type>
<db:parameter>string</db:parameter>
</db:methodparam>
<db:modifier>overload</db:modifier>
<db:synopsisinfo role="meta">constructor</db:synopsisinfo>
<db:synopsisinfo role="overload-number">3</db:synopsisinfo>
<db:synopsisinfo role="signature">QXmlStreamWriter(QString *string)</db:synopsisinfo>
<db:synopsisinfo role="access">public</db:synopsisinfo>
<db:synopsisinfo role="status">active</db:synopsisinfo>
<db:synopsisinfo role="threadsafeness">unspecified</db:synopsisinfo>
</db:constructorsynopsis>
```

This is a description of https://doc.qt.io/qt-6/qxmlstreamwriter.html#QXmlStreamWriter-3