### PR TITLE
Allow foreign namespace-qualified attributes on DocBook elements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -382,9 +382,9 @@ fileTree(dir: "${projectDir}/src/test").each { testfile ->
         input document
         output "${buildDir}/test/rng/${fn}"
         schema "${buildDir}/schemas/rng/${packageMap[schema_name]}/${schema_name}.rng"
-        errorHandler new CollectingErrorHandler()
+        errorHandler new CollectingErrorHandler(System.err)
         idref (schema_name != 'website' && schema_name != 'website-full' && schema_name != 'dbforms')
-        assertValid false
+        assertValid true
       }
       pass_tests.dependsOn t
       baseTests[schema_name].dependsOn t
@@ -394,9 +394,9 @@ fileTree(dir: "${projectDir}/src/test").each { testfile ->
         input document
         output "${buildDir}/test/sch/${fn}"
         schema "${buildDir}/schemas/sch/${packageMap[schema_name]}/${schema_name}.sch"
-        errorHandler new CollectingErrorHandler()
+        errorHandler new CollectingErrorHandler(System.err)
         idref (schema_name != 'website' && schema_name != 'website-full' && schema_name != 'dbforms')
-        assertValid false
+        assertValid true
       }
       pass_tests.dependsOn t
       baseTests[schema_name].dependsOn t

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,8 @@ org.gradle.workers.max=3
 systemProp.javax.xml.transform.TransformerFactory=net.sf.saxon.TransformerFactoryImpl
 
 saxonVersion = 11.3
-resolverVersion = 4.4.3
-dbver = 5.2CR2
+resolverVersion = 4.5.0
+dbver = 5.2CR3
 xslTNGversion = 1.7.1
 
 oasisDocBookVersion=5.2

--- a/src/dbits/relaxng/dbits/dbits.rnc
+++ b/src/dbits/relaxng/dbits/dbits.rnc
@@ -72,6 +72,10 @@
 namespace db = "http://docbook.org/ns/docbook"
 namespace its = "http://www.w3.org/2005/11/its"
 namespace html = "http://www.w3.org/1999/xhtml"
+namespace xml = "http://www.w3.org/XML/1998/namespace"
+namespace xlink = "http://www.w3.org/1999/xlink"
+namespace trans = "http://docbook.org/ns/transclusion"
+namespace local = ""
 
 include "../../../docbook/relaxng/docbook/docbook.rnc" {
    # Exclude ITS markup from "wildcard" element
@@ -81,6 +85,13 @@ include "../../../docbook/relaxng/docbook/docbook.rnc" {
           | text
           | db._any)*
       }
+
+   # Exclude ITS markup from "any other" attribute
+   db._any_other.attribute =
+       [
+         db:refpurpose [ "Any attribute in an other explicit namespace." ]
+       ]
+       attribute * - (db:* | xml:* | xlink:* | trans:* | its:* | local:*) { text }
 }
 
 # Include base ITS schema

--- a/src/dbits/relaxng/dbitsxi/dbitsxi.rnc
+++ b/src/dbits/relaxng/dbitsxi/dbitsxi.rnc
@@ -4,6 +4,10 @@ namespace db = "http://docbook.org/ns/docbook"
 namespace src = "http://nwalsh.com/xmlns/litprog/fragment"
 namespace html = "http://www.w3.org/1999/xhtml"
 namespace its = "http://www.w3.org/2005/11/its"
+namespace xml = "http://www.w3.org/XML/1998/namespace"
+namespace xlink = "http://www.w3.org/1999/xlink"
+namespace trans = "http://docbook.org/ns/transclusion"
+namespace local = ""
 default namespace = "http://docbook.org/ns/docbook"
 
 include "../../../docbook/relaxng/docbookxi/docbookxi.rnc" {
@@ -14,6 +18,13 @@ include "../../../docbook/relaxng/docbookxi/docbookxi.rnc" {
           | text
           | db._any)*
       }
+
+   # Exclude ITS markup from "any other" attribute
+   db._any_other.attribute =
+       [
+         db:refpurpose [ "Any attribute in an other explicit namespace." ]
+       ]
+       attribute * - (db:* | xml:* | xlink:* | trans:* | its:* | local:*) { text }
 }
 
 # Include base ITS schema

--- a/src/docbook/java/org/docbook/schemas/docbook/DocBook.java
+++ b/src/docbook/java/org/docbook/schemas/docbook/DocBook.java
@@ -7,7 +7,7 @@ package org.docbook.schemas.docbook;
 // some tests to make sure the testing version is correct.
 
 public final class DocBook {
-  public static final String[] VERSIONS = {"4.5", "5.0", "5.1", "5.2", "5.2CR2"};
+  public static final String[] VERSIONS = {"4.5", "5.0", "5.1", "5.2", "5.2CR3"};
 
   public static final String DOCBOOK_CATALOG_PATH = "/org/docbook/schemas/docbook/catalog.xml";
 

--- a/src/docbook/relaxng/docbook/pool.rnc
+++ b/src/docbook/relaxng/docbook/pool.rnc
@@ -3,10 +3,12 @@ namespace rng  = "http://relaxng.org/ns/structure/1.0"
 namespace s = "http://purl.oclc.org/dsdl/schematron"
 namespace db = "http://docbook.org/ns/docbook"
 namespace dbx = "http://sourceforge.net/projects/docbook/defguide/schema/extra-markup"
+namespace xml = "http://www.w3.org/XML/1998/namespace"
 namespace xlink = "http://www.w3.org/1999/xlink"
 namespace trans = "http://docbook.org/ns/transclusion"
 namespace html = "http://www.w3.org/1999/xhtml"
 namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
+namespace local = ""
 default namespace = "http://docbook.org/ns/docbook"
 
 # ======================================================================
@@ -52,6 +54,12 @@ div {
          db:refpurpose [ "Any attribute, including any attribute in any namespace." ]
       ]
       attribute * { text }
+
+   db._any_other.attribute =
+       [
+         db:refpurpose [ "Any attribute in an other explicit namespace." ]
+       ]
+       attribute * - (db:* | xml:* | xlink:* | trans:* | local:*) { text }
 
    db._any =
       element * - db:* { (db._any.attribute | text | db._any)* }
@@ -452,6 +460,7 @@ db.common.base.attributes =
  & db.effectivity.attributes
  & db.rdfalite.attributes
  & db.common.transclusion.attributes
+ & db._any_other.attribute*
 
 db.common.attributes =
    db.xml.id.attribute?

--- a/src/publishers/java/org/docbook/schemas/publishers/Publishers.java
+++ b/src/publishers/java/org/docbook/schemas/publishers/Publishers.java
@@ -7,7 +7,7 @@ package org.docbook.schemas.publishers;
 // some tests to make sure the testing version is correct.
 
 public final class Publishers {
-  public static final String[] VERSIONS = {"1.0", "5.2", "5.2CR2"};
+  public static final String[] VERSIONS = {"1.0", "5.2", "5.2CR3"};
 
   public static final String PUBLISHERS_CATALOG_PATH = "/org/docbook/schemas/publishers/catalog.xml";
 

--- a/src/test/relaxng/dbforms/pass/form-001.xml
+++ b/src/test/relaxng/dbforms/pass/form-001.xml
@@ -1,7 +1,7 @@
 <article xmlns="http://docbook.org/ns/docbook"
          version="htmlforms-5.2">
 <title>A forms example</title>
-<form xmlns="http://www.w3.org/1999/xhtml">
+<form xmlns="http://www.w3.org/1999/xhtml" action="http://example.com/">
 <input name="text"/>
 </form>
 </article>

--- a/src/test/relaxng/docbook/fail/foreign-ns.001.xml
+++ b/src/test/relaxng/docbook/fail/foreign-ns.001.xml
@@ -1,0 +1,9 @@
+<article xmlns="http://docbook.org/ns/docbook"
+         version="5.2">
+<title>Article wrapper</title>
+
+<para unqualified-name="this is not allowed">You can put foreign namespaced
+elements on any DocBook element. They must be in an explicit
+namespace other than the DocBook namespace.</para>
+
+</article>

--- a/src/test/relaxng/docbook/fail/foreign-ns.002.xml
+++ b/src/test/relaxng/docbook/fail/foreign-ns.002.xml
@@ -1,0 +1,10 @@
+<article xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         version="5.2">
+<title>Article wrapper</title>
+
+<para db:name="this is also not ok">You can put foreign namespaced
+elements on any DocBook element. They must be in an explicit
+namespace other than the DocBook namespace.</para>
+
+</article>

--- a/src/test/relaxng/docbook/pass/foreign-ns.001.xml
+++ b/src/test/relaxng/docbook/pass/foreign-ns.001.xml
@@ -1,0 +1,10 @@
+<article xmlns="http://docbook.org/ns/docbook"
+         xmlns:ex="http://example.com/"
+         version="5.2">
+<title>Article wrapper</title>
+
+<para ex:name="this is ok">You can put foreign namespaced
+elements on any DocBook element. They must be in an explicit
+namespace other than the DocBook namespace.</para>
+
+</article>

--- a/src/test/relaxng/docbook/pass/xref.002.xml
+++ b/src/test/relaxng/docbook/pass/xref.002.xml
@@ -1,8 +1,7 @@
 <article xmlns="http://docbook.org/ns/docbook" version="5.0">
 <info>
 <title>Article wrapper</title>
-<x:irrelevant xmlns:x="http://example.com/doesntmatter"
-              xml:id="xreftext">Xref Endterm</x:irrelevant>
+<bibliomisc role="xreftext" xml:id="xreftext">Xref Endterm</bibliomisc>
 </info>
 
 <para>This is an xref test.</para>


### PR DESCRIPTION
This PR allows "other" attributes on elements in the DocBook namespace. Other attributes are defined as attributes from an explicit namespace other than the DocBook, XML, XLink, or Transclusion namespaces. For the DocBook ITS schema, attributes from the ITS namespace are also excluded. 

Fix #236 