### PR TITLE
Fix XInclude declarations, inconsistencies

### DIFF
--- a/src/docbook/relaxng/assemblyxi/xinclude.rnc
+++ b/src/docbook/relaxng/assemblyxi/xinclude.rnc
@@ -24,6 +24,8 @@ div {
       attribute href { xsd:anyURI { pattern = "[^#]+" } }?,
       [ a:defaultValue="xml" ] attribute parse { "xml" | "text" }?,
       attribute xpointer { text }?,
+      attribute fragid { text }?,
+      attribute set-xml-id { text }?,
       attribute encoding { text }?,
       attribute accept { text }?,
       attribute accept-language { text }?,

--- a/src/docbook/relaxng/docbookxi/xinclude.rnc
+++ b/src/docbook/relaxng/docbookxi/xinclude.rnc
@@ -208,10 +208,11 @@ div {
    db.any.other.attribute = attribute * - local:* { text }
 
    db.xi.include.attlist =
-      attribute href { xsd:anyURI }?,
+      attribute href { xsd:anyURI { pattern = "[^#]+" } }?,
       [ a:defaultValue="xml" ] attribute parse { "xml" | "text" }?,
       attribute xpointer { text }?,
       attribute fragid { text }?,
+      attribute set-xml-id { text }?,
       attribute encoding { text }?,
       attribute accept { text }?,
       attribute accept-language { text }?,


### PR DESCRIPTION
This PR fixes the declarations of XInclude in the versions of DocBook and Assembly schemas that support XInclude.

1. It adds the missing `set-xml-id` attribute from XInclude 1.1. Close #239 
2. It makes the declarations consistent with each other

Note that the `set-xml-id` attribute cannot be declared with the type `xsd:ID` because you may not have two attributes with that type and the XInclude attribute could potentially have its own `xml:id`. 