### PR TITLE
Fix OASIS identifiers in catalog, CR4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,11 @@ systemProp.javax.xml.transform.TransformerFactory=net.sf.saxon.TransformerFactor
 
 saxonVersion = 11.3
 resolverVersion = 4.5.0
-dbver = 5.2CR3
+dbver = 5.2CR4
 xslTNGversion = 1.7.1
 
 oasisDocBookVersion=5.2
-oasisDocBookRelease=wd01
+oasisDocBookRelease=csd01
 
 oasisPublishersVersion=5.2
-oasisPublishersRelease=wd01
+oasisPublishersRelease=csd01

--- a/src/docbook/java/org/docbook/schemas/docbook/DocBook.java
+++ b/src/docbook/java/org/docbook/schemas/docbook/DocBook.java
@@ -7,7 +7,7 @@ package org.docbook.schemas.docbook;
 // some tests to make sure the testing version is correct.
 
 public final class DocBook {
-  public static final String[] VERSIONS = {"4.5", "5.0", "5.1", "5.2", "5.2CR3"};
+  public static final String[] VERSIONS = {"4.5", "5.0", "5.1", "5.2", "5.2CR4"};
 
   public static final String DOCBOOK_CATALOG_PATH = "/org/docbook/schemas/docbook/catalog.xml";
 

--- a/src/publishers/java/org/docbook/schemas/publishers/Publishers.java
+++ b/src/publishers/java/org/docbook/schemas/publishers/Publishers.java
@@ -7,7 +7,7 @@ package org.docbook.schemas.publishers;
 // some tests to make sure the testing version is correct.
 
 public final class Publishers {
-  public static final String[] VERSIONS = {"1.0", "5.2", "5.2CR3"};
+  public static final String[] VERSIONS = {"1.0", "5.2", "5.2CR4"};
 
   public static final String PUBLISHERS_CATALOG_PATH = "/org/docbook/schemas/publishers/catalog.xml";
 


### PR DESCRIPTION
This PR fixes the OASIS identifiers in `catalog.xml` for the `csd01` release.

It also advances the published version to CR4.
