### PR TITLE
Correct typo and use long form of ITS

### DIFF
--- a/src/docbook/xml/release-notes.xml
+++ b/src/docbook/xml/release-notes.xml
@@ -73,7 +73,7 @@ elements support legal sections.
 </listitem>
 <listitem>
 <simpara>Added XInclude-enabled schema versions of Assembly and
-BITS schemas.</simpara>
+International Tag Set (<acronym>ITS</acronym>) schemas.</simpara>
 </listitem>
 </orderedlist>
 </section>


### PR DESCRIPTION
This is just a typo fix. As not everybody is familiar with ITS, I've added also the long form plus the acronym.