### PR TITLE
Add missing topics for 5.2CR4 release notes

### DIFF
--- a/src/docbook/xml/release-notes.xml
+++ b/src/docbook/xml/release-notes.xml
@@ -75,6 +75,18 @@ elements support legal sections.
 <simpara>Added XInclude-enabled schema versions of Assembly and
 BITS schemas.</simpara>
 </listitem>
+<listitem>
+<simpara>Added missing <tag class="attribute">fragid</tag> and
+<tag class="attribute">set-xml-id</tag> to the XInclude-enabled schema.
+</simpara>
+</listitem>
+<listitem>
+<simpara>Allow <tag>info</tag> as top-level element.</simpara>
+</listitem>
+<listitem>
+<simpara>Allow foreign namespace-qualified attributes on DocBook elements.
+</simpara>
+</listitem>
 </orderedlist>
 </section>
 


### PR DESCRIPTION
Mentioned in this PR:

* `fragid` and `set-xml-id` attributes for XInclude-enabled schema
* Mention `<info>` as root element
* Mention foreign namespace-qualified attributes on all DocBook elements

IMHO, these are worth to mention in the release notes. :slightly_smiling_face: 