### PR TITLE
DocBook 5.2 OASIS Standard drafts and infrastructure updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -570,7 +570,7 @@ task docbook_javaConfig() {
       jver = br.readLine()
     }
   }
-  def expect = "{'4.5', '5.0', '5.1', '5.2', '${dbver}'};".replace('\'', '"')
+  def expect = "{'4.5', '5.0', '5.1', '${dbver}'};".replace('\'', '"')
   if (jver != expect) {
     throw new GradleException("Check VERSIONS in DocBook.java; ${expect} != ${jver}")
   }
@@ -646,14 +646,14 @@ task docbook_javadoc(type: Javadoc) {
 
 task docbook_javadocJar(type: Jar, dependsOn: ["docbook_javadoc"]) {
   archiveBaseName = "docbook-${dbver}"
-  classifier = 'javadoc'
+  archiveClassifier = 'javadoc'
   from docbook_javadoc.destinationDir
 }
 assemble.dependsOn docbook_javadocJar
 
 task docbook_sourcesJar(type: Jar) {
   archiveBaseName = "docbook-${dbver}"
-  classifier = 'sources'
+  archiveClassifier = 'sources'
   from sourceSets.docbook.allSource
 }
 assemble.dependsOn docbook_sourcesJar
@@ -673,9 +673,9 @@ task publishers_javaConfig() {
       jver = br.readLine()
     }
   }
-  def expect = "{'1.0', '5.2', '${dbver}'};".replace('\'', '"')
+  def expect = "{'1.0', '${dbver}'};".replace('\'', '"')
   if (jver != expect) {
-    throw new GradleException("Check VERSIONS in DocBook.java; ${expect} != ${jver}")
+    throw new GradleException("Check VERSIONS in Publishers.java; ${expect} != ${jver}")
   }
 }
 
@@ -746,14 +746,14 @@ task publishers_javadoc(type: Javadoc) {
 
 task publishers_javadocJar(type: Jar, dependsOn: ["publishers_javadoc"]) {
   archiveBaseName = "publishers-${dbver}"
-  classifier = 'javadoc'
+  archiveClassifier = 'javadoc'
   from publishers_javadoc.destinationDir
 }
 assemble.dependsOn publishers_javadocJar
 
 task publishers_sourcesJar(type: Jar) {
   archiveBaseName = "publishers-${dbver}"
-  classifier = 'sources'
+  archiveClassifier = 'sources'
   from sourceSets.publishers.allSource
 }
 assemble.dependsOn publishers_sourcesJar

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,12 @@
-org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=4096m -Dfile.encoding=UTF-8
-org.gradle.parallel=true
-org.gradle.workers.max=3
-
 systemProp.javax.xml.transform.TransformerFactory=net.sf.saxon.TransformerFactoryImpl
 
-saxonVersion = 11.5
-resolverVersion = 4.6.4
-dbver = 5.2CR5
+saxonVersion = 12.4
+resolverVersion = 5.2.3
+dbver = 5.2
 xslTNGversion = 1.11.1
 
 oasisDocBookVersion=5.2
-oasisDocBookRelease=csd01
+oasisDocBookRelease=os
 
 oasisPublishersVersion=5.2
-oasisPublishersRelease=csd01
+oasisPublishersRelease=os

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/docbook/java/org/docbook/schemas/docbook/DocBook.java
+++ b/src/docbook/java/org/docbook/schemas/docbook/DocBook.java
@@ -7,7 +7,7 @@ package org.docbook.schemas.docbook;
 // some tests to make sure the testing version is correct.
 
 public final class DocBook {
-  public static final String[] VERSIONS = {"4.5", "5.0", "5.1", "5.2", "5.2CR5"};
+  public static final String[] VERSIONS = {"4.5", "5.0", "5.1", "5.2"};
 
   public static final String DOCBOOK_CATALOG_PATH = "/org/docbook/schemas/docbook/catalog.xml";
 

--- a/src/publishers/java/org/docbook/schemas/publishers/Publishers.java
+++ b/src/publishers/java/org/docbook/schemas/publishers/Publishers.java
@@ -7,7 +7,7 @@ package org.docbook.schemas.publishers;
 // some tests to make sure the testing version is correct.
 
 public final class Publishers {
-  public static final String[] VERSIONS = {"1.0", "5.2", "5.2CR5"};
+  public static final String[] VERSIONS = {"1.0", "5.2"};
 
   public static final String PUBLISHERS_CATALOG_PATH = "/org/docbook/schemas/publishers/catalog.xml";
 


### PR DESCRIPTION
There are no schema changes here, just changes in the metadata for the "os" release of DocBook 5.2